### PR TITLE
[R4R] modify params for Parlia consensus with 21 validators

### DIFF
--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -37,7 +37,7 @@ const (
 )
 
 const (
-	maxUncleDist = 7   // Maximum allowed backward distance from the chain head
+	maxUncleDist = 11  // Maximum allowed backward distance from the chain head
 	maxQueueDist = 32  // Maximum allowed distance from the chain head to queue
 	hashLimit    = 256 // Maximum number of unique blocks a peer may have announced
 	blockLimit   = 64  // Maximum number of unique blocks a peer may have delivered

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -56,7 +56,7 @@ const (
 	resubmitAdjustChanSize = 10
 
 	// miningLogAtDepth is the number of confirmations before logging successful mining.
-	miningLogAtDepth = 15
+	miningLogAtDepth = 11
 
 	// minRecommitInterval is the minimal time interval to recreate the mining block with
 	// any newly arrived transactions.
@@ -75,7 +75,7 @@ const (
 	intervalAdjustBias = 200 * 1000.0 * 1000.0
 
 	// staleThreshold is the maximum depth of the acceptable stale block.
-	staleThreshold = 7
+	staleThreshold = 11
 )
 
 var (
@@ -356,7 +356,7 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 			commit(false, commitInterruptNewHead)
 
 		case head := <-w.chainHeadCh:
-			if !w.isRunning(){
+			if !w.isRunning() {
 				continue
 			}
 			clearPending(head.Block.NumberU64())


### PR DESCRIPTION
In mainnet, bsc will have 21 validators. It will reach finality after 11 blocks. resolve #7

Meaning :
1. `BlockFetcher`: block fetcher will ignore block who's num is before `currentNum-maxUncleDist`.
2. `staleThreshold`: miner module will clean works that before `currentNum-staleThreshold`.
3. `miningLogAtDepth`: will report finality when one block is `miningLogAtDepth` before `currentNum`.
