### PR TITLE
[R4R]reestimate the gas consumption for system tx when there is 41 validator

### DIFF
--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -29,7 +29,7 @@ const (
 	CallValueTransferGas  uint64 = 9000   // Paid for CALL when the value transfer is non-zero.
 	CallNewAccountGas     uint64 = 25000  // Paid for CALL when the destination address didn't exist prior.
 	TxGas                 uint64 = 21000  // Per transaction not creating a contract. NOTE: Not payable on data of calls between transactions.
-	SystemTxsGas          uint64 = 100000 // The gas reserved for system txs; only for parlia consensus
+	SystemTxsGas          uint64 = 500000 // The gas reserved for system txs; only for parlia consensus
 	TxGasContractCreation uint64 = 53000  // Per transaction that creates a contract. NOTE: Not payable on data of calls between transactions.
 	TxDataZeroGas         uint64 = 4      // Per byte of data attached to a transaction that equals zero. NOTE: Not payable on data of calls between transactions.
 	QuadCoeffDiv          uint64 = 512    // Divisor for the quadratic particle of the memory cost equation.


### PR DESCRIPTION
Have test slash transaction when there are 41 validators, the max gas consumption could be 434543,  adjust SystemTxsGas to  500000 would be safe