### PR TITLE
[R4R]support fork id in header; elegant upgrade

### DIFF
--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -18,6 +18,7 @@ package parlia
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"math/big"
@@ -38,10 +39,11 @@ type Snapshot struct {
 	ethAPI   *ethapi.PublicBlockChainAPI
 	sigCache *lru.ARCCache // Cache of recent block signatures to speed up ecrecover
 
-	Number     uint64                      `json:"number"`     // Block number where the snapshot was created
-	Hash       common.Hash                 `json:"hash"`       // Block hash where the snapshot was created
-	Validators map[common.Address]struct{} `json:"validators"` // Set of authorized validators at this moment
-	Recents    map[uint64]common.Address   `json:"recents"`    // Set of recent validators for spam protections
+	Number           uint64                      `json:"number"`             // Block number where the snapshot was created
+	Hash             common.Hash                 `json:"hash"`               // Block hash where the snapshot was created
+	Validators       map[common.Address]struct{} `json:"validators"`         // Set of authorized validators at this moment
+	Recents          map[uint64]common.Address   `json:"recents"`            // Set of recent validators for spam protections
+	RecentForkHashes map[uint64]string           `json:"recent_fork_hashes"` // Set of recent forkHash
 }
 
 // newSnapshot creates a new snapshot with the specified startup parameters. This
@@ -56,13 +58,14 @@ func newSnapshot(
 	ethAPI *ethapi.PublicBlockChainAPI,
 ) *Snapshot {
 	snap := &Snapshot{
-		config:     config,
-		ethAPI:     ethAPI,
-		sigCache:   sigCache,
-		Number:     number,
-		Hash:       hash,
-		Recents:    make(map[uint64]common.Address),
-		Validators: make(map[common.Address]struct{}),
+		config:           config,
+		ethAPI:           ethAPI,
+		sigCache:         sigCache,
+		Number:           number,
+		Hash:             hash,
+		Recents:          make(map[uint64]common.Address),
+		RecentForkHashes: make(map[uint64]string),
+		Validators:       make(map[common.Address]struct{}),
 	}
 	for _, v := range validators {
 		snap.Validators[v] = struct{}{}
@@ -106,13 +109,14 @@ func (s *Snapshot) store(db ethdb.Database) error {
 // copy creates a deep copy of the snapshot
 func (s *Snapshot) copy() *Snapshot {
 	cpy := &Snapshot{
-		config:     s.config,
-		ethAPI:     s.ethAPI,
-		sigCache:   s.sigCache,
-		Number:     s.Number,
-		Hash:       s.Hash,
-		Validators: make(map[common.Address]struct{}),
-		Recents:    make(map[uint64]common.Address),
+		config:           s.config,
+		ethAPI:           s.ethAPI,
+		sigCache:         s.sigCache,
+		Number:           s.Number,
+		Hash:             s.Hash,
+		Validators:       make(map[common.Address]struct{}),
+		Recents:          make(map[uint64]common.Address),
+		RecentForkHashes: make(map[uint64]string),
 	}
 
 	for v := range s.Validators {
@@ -121,7 +125,20 @@ func (s *Snapshot) copy() *Snapshot {
 	for block, v := range s.Recents {
 		cpy.Recents[block] = v
 	}
+	for block, id := range s.RecentForkHashes {
+		cpy.RecentForkHashes[block] = id
+	}
 	return cpy
+}
+
+func (s *Snapshot) isMajorityFork(forkHash string) bool {
+	ally := 0
+	for _, h := range s.RecentForkHashes {
+		if h == forkHash {
+			ally++
+		}
+	}
+	return ally > len(s.RecentForkHashes)/2
 }
 
 func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainReader, parents []*types.Header, chainId *big.Int) (*Snapshot, error) {
@@ -152,6 +169,9 @@ func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainReader, p
 		// Delete the oldest validator from the recent list to allow it signing again
 		if limit := uint64(len(snap.Validators)/2 + 1); number >= limit {
 			delete(snap.Recents, number-limit)
+		}
+		if limit := uint64(len(snap.Validators)); number >= limit {
+			delete(snap.RecentForkHashes, number-limit)
 		}
 		// Resolve the authorization key and check against signers
 		validator, err := ecrecover(header, s.sigCache, chainId)
@@ -191,8 +211,10 @@ func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainReader, p
 					delete(snap.Recents, number-uint64(newLimit)-uint64(i))
 				}
 			}
+			snap.RecentForkHashes = make(map[uint64]string, 0)
 			snap.Validators = newVals
 		}
+		snap.RecentForkHashes[number] = hex.EncodeToString(header.Extra[extraVanity-nextForkHashSize : extraVanity])
 	}
 	snap.Number += uint64(len(headers))
 	snap.Hash = headers[len(headers)-1].Hash()

--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -211,7 +211,13 @@ func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainReader, p
 					delete(snap.Recents, number-uint64(newLimit)-uint64(i))
 				}
 			}
-			snap.RecentForkHashes = make(map[uint64]string, 0)
+			oldLimit = len(snap.Validators)
+			newLimit = len(newVals)
+			if newLimit < oldLimit {
+				for i := 0; i < oldLimit-newLimit; i++ {
+					delete(snap.RecentForkHashes, number-uint64(newLimit)-uint64(i))
+				}
+			}
 			snap.Validators = newVals
 		}
 		snap.RecentForkHashes[number] = hex.EncodeToString(header.Extra[extraVanity-nextForkHashSize : extraVanity])

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -158,7 +158,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 
 	eth.APIBackend = &EthAPIBackend{ctx.ExtRPCEnabled(), eth, nil}
 	ethAPI := ethapi.NewPublicBlockChainAPI(eth.APIBackend)
-	eth.engine = CreateConsensusEngine(ctx, chainConfig, &config.Ethash, config.Miner.Notify, config.Miner.Noverify, chainDb, ethAPI)
+	eth.engine = CreateConsensusEngine(ctx, chainConfig, &config.Ethash, config.Miner.Notify, config.Miner.Noverify, chainDb, ethAPI, genesisHash)
 
 	bcVersion := rawdb.ReadDatabaseVersion(chainDb)
 	var dbVer = "<nil>"
@@ -243,21 +243,21 @@ func makeExtraData(extra []byte) []byte {
 			runtime.GOOS,
 		})
 	}
-	if uint64(len(extra)) > params.MaximumExtraDataSize {
-		log.Warn("Miner extra data exceed limit", "extra", hexutil.Bytes(extra), "limit", params.MaximumExtraDataSize)
+	if uint64(len(extra)) > params.MaximumExtraDataSize-params.ForkIDSize {
+		log.Warn("Miner extra data exceed limit", "extra", hexutil.Bytes(extra), "limit", params.MaximumExtraDataSize-params.ForkIDSize)
 		extra = nil
 	}
 	return extra
 }
 
 // CreateConsensusEngine creates the required type of consensus engine instance for an Ethereum service
-func CreateConsensusEngine(ctx *node.ServiceContext, chainConfig *params.ChainConfig, config *ethash.Config, notify []string, noverify bool, db ethdb.Database, ee *ethapi.PublicBlockChainAPI) consensus.Engine {
+func CreateConsensusEngine(ctx *node.ServiceContext, chainConfig *params.ChainConfig, config *ethash.Config, notify []string, noverify bool, db ethdb.Database, ee *ethapi.PublicBlockChainAPI, genesisHash common.Hash) consensus.Engine {
 	// If proof-of-authority is requested, set it up
 	if chainConfig.Clique != nil {
 		return clique.New(chainConfig.Clique, db)
 	}
 	if chainConfig.Parlia != nil {
-		return parlia.New(chainConfig, db, ee)
+		return parlia.New(chainConfig, db, ee, genesisHash)
 	}
 	// Otherwise assume proof-of-work
 	switch config.PowMode {

--- a/les/client.go
+++ b/les/client.go
@@ -102,7 +102,7 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 		eventMux:       ctx.EventMux,
 		reqDist:        newRequestDistributor(peers, &mclock.System{}),
 		accountManager: ctx.AccountManager,
-		engine:         eth.CreateConsensusEngine(ctx, chainConfig, &config.Ethash, nil, false, chainDb, nil),
+		engine:         eth.CreateConsensusEngine(ctx, chainConfig, &config.Ethash, nil, false, chainDb, nil, genesisHash),
 		bloomRequests:  make(chan chan *bloombits.Retrieval),
 		bloomIndexer:   eth.NewBloomIndexer(chainDb, params.BloomBitsBlocksClient, params.HelperTrieConfirmations),
 		serverPool:     newServerPool(chainDb, config.UltraLightServers),

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -24,6 +24,7 @@ const (
 	GenesisGasLimit      uint64 = 4712388 // Gas limit of the Genesis block.
 
 	MaximumExtraDataSize  uint64 = 32     // Maximum size extra data may be after Genesis.
+	ForkIDSize            uint64 = 4      // The length of fork id
 	ExpByteGas            uint64 = 10     // Times ceil(log256(exponent)) for the EXP instruction.
 	SloadGas              uint64 = 50     // Multiplied by the number of 32-byte words that are copied (round up) for any *COPY operation and added.
 	CallValueTransferGas  uint64 = 9000   // Paid for CALL when the value transfer is non-zero.


### PR DESCRIPTION
# BEP-87: Visual Fork of Binance Smart Chain

- BEP-87: Visual Fork of Binance Smart Chain
  - [1. Summary](#1-summary)
  - [2. Abstract](#2-abstract)
  - [3. Status](#3-status)
  - [4. Motivation](#4-motivation)
  - [5. Specification](#5-specification)
    - [5.1 Fork Hash](#51-fork-hash)
    - [5.2 Vanity](#52-vanity)
    - [5.3 Vanity](#53-clients)
    - [5.4 Backwards Compatibility](#54-backwards-compatibility)
  - [6. License](#6-license)

## 1.  Summary 

This BEP describes a proposal to enable the chain to display the whole view of validators that on different upcoming forks.  

## 2.  Abstract

The four bytes of `Header.Extra[28:32]` will be fulfilled with `NEXT_FORK_HASH`. The `NEXT_FORK_HASH` indicates which fork the signer of this block is going to stay on. By analysing `N` (`N` is the amount of validators) continuous block headers, we are able to know which fork is supported by the majority of validators and exact which validator has not upgraded yet. 

## 3.  Status

Draft.

## 4.  Motivation

Binance Smart Chain will have some hard forks inevitably in the long run. Binance Smart Chain takes a risk of halt during hard fork once the validators can not reach a consensus. A validator could be slashed if it is not on the canonical fork which could be avoidable if the maintainer received alerts in time. A new protocol should be introduced to enable the chain to display the whole view of validators that on different upcoming forks. Any nodes/validators can decide to upgrade/fork or not accordingly.

## 5.  Specification

###  5.1 Fork Hash

Fork Hash is introduced in [EIP-2124](https://eips.ethereum.org/EIPS/eip-2124). It is a mechanism that can let ethereum nodes precisely identify whether another node will be useful. 

- `FORK_HASH`. IEEE CRC32 checksum ([4]byte) of the genesis hash and fork blocks numbers that already passed. E.g. Fork Hash for mainnet would be: `forkhash₂ = 0x91d1f948 (DAO fork) = CRC32(<genesis-hash> || uint64(1150000) || uint64(1920000))`.
- `FORK_NEXT`. Block number (uint64) of the next upcoming fork, or 0 if no next fork is known.
- `NEXT_FORK_HASH`, whose algorithm is same with `FORK_HASH`, but `FORK_NEXT` will be included as well if it is not 0.

### 5.2 Vanity

Format of `Header.Extra`: 

```
|   32 bytes       |       20 * N bytes      |   65 bytes     |
|   extraVanity    |   validatorSetBytes     |   extraSeal    |
```

`extraVanity` field is customized now, validator can use it to record `NEXT_FORK_HASH` of itself. The `NEXT_FORK_HASH` will only use the last 4 bytes of `extraVanity`.

### 5.3 Clients

- For validator. It will fill in `Header.Extra` with `NEXT_FORK_HASH` during preparing block header.
- For witness. It will log a warning message if the majority `NEXT_FORK_HASH` is different from local.
- For light client. No impact.

### 5.4 Backwards Compatibility

- This BEP itself is not a hardfork one, it breaks nothing of consensus. 
- Downstream service is completely compatible with this BEP.

## 6. License

The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
