### PR TITLE
[R4R]les: fix GetProofsV2 bug (#21896)

### DIFF
--- a/les/server_handler.go
+++ b/les/server_handler.go
@@ -582,6 +582,7 @@ func (h *serverHandler) handleMsg(p *clientPeer, wg *sync.WaitGroup) error {
 		var (
 			lastBHash common.Hash
 			root      common.Hash
+			header    *types.Header
 		)
 		reqCnt := len(req.Reqs)
 		if accept(req.ReqID, uint64(reqCnt), MaxProofsFetch) {
@@ -596,10 +597,6 @@ func (h *serverHandler) handleMsg(p *clientPeer, wg *sync.WaitGroup) error {
 						return
 					}
 					// Look up the root hash belonging to the request
-					var (
-						header *types.Header
-						trie   state.Trie
-					)
 					if request.BHash != lastBHash {
 						root, lastBHash = common.Hash{}, request.BHash
 
@@ -626,6 +623,7 @@ func (h *serverHandler) handleMsg(p *clientPeer, wg *sync.WaitGroup) error {
 					// Open the account or storage trie for the request
 					statedb := h.blockchain.StateCache()
 
+					var trie state.Trie
 					switch len(request.AccKey) {
 					case 0:
 						// No account key specified, open an account trie


### PR DESCRIPTION
### Description

This PR fixes a bug in GetProofsV2 request serving that could potentially cause a panic because of header being nil.

### Rationale
A DoS vulnerability can make a LES server crash via malicious GetProofsV2 request from a connected LES client.


### Example
Mirror PR:  https://github.com/ethereum/go-ethereum/pull/21896
advisories: https://github.com/ethereum/go-ethereum/security/advisories/GHSA-r33q-22hv-j29q
### Changes

This vulnerability only concerns users explicitly enabling les server; disabling les prevents the exploit.

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
