### PR TITLE
[R4R]add curl in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN cd /go-ethereum && make geth
 # Pull Geth into a second stage deploy alpine container
 FROM alpine:latest
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates curl
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
 
 EXPOSE 8545 8546 8547 30303 30303/udp


### PR DESCRIPTION
### Description
We need build a kubernets data-seed cluster, and we want to add `curl` cmd to the running docker instance, so that we can use it to test whether the node is catch up not not, as a metrics of readiness.
### Rationale
Just add `curl` in docker file

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
