### PR TITLE
[R4R]add rpc method request gauge

### DIFF
--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -340,6 +340,7 @@ func (h *handler) handleCall(cp *callProc, msg *jsonrpcMessage) *jsonrpcMessage 
 			successfulRequestGauge.Inc(1)
 		}
 		rpcServingTimer.UpdateSince(start)
+		newRPCRequestGauge(msg.Method).Inc(1)
 		newRPCServingTimer(msg.Method, answer.Error == nil).UpdateSince(start)
 	}
 	return answer

--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -37,3 +37,8 @@ func newRPCServingTimer(method string, valid bool) metrics.Timer {
 	m := fmt.Sprintf("rpc/duration/%s/%s", method, flag)
 	return metrics.GetOrRegisterTimer(m, nil)
 }
+
+func newRPCRequestGauge(method string) metrics.Gauge {
+	m := fmt.Sprintf("rpc/count/%s", method)
+	return metrics.GetOrRegisterGauge(m, nil)
+}


### PR DESCRIPTION
### Description
We need to do statistics of different kinds of requests, so add request count gauge for each kind of request.

### Rationale
Metrics change.

### Example
No
### Changes
Add more monitor dashboard

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] manual transaction test passed

### Already reviewed by

...

### Related issues

No
