### PR TITLE
[R4R]validator only write database state when enough distance

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -133,4 +133,5 @@ type PoSA interface {
 
 	IsSystemTransaction(tx *types.Transaction, header *types.Header) (bool, error)
 	IsSystemContract(to *common.Address) bool
+	EnoughDistance(chain ChainReader, header *types.Header) bool
 }

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -852,6 +852,14 @@ func (p *Parlia) Seal(chain consensus.ChainReader, block *types.Block, results c
 	return nil
 }
 
+func (p *Parlia) EnoughDistance(chain consensus.ChainReader, header *types.Header) bool {
+	snap, err := p.snapshot(chain, header.Number.Uint64()-1, header.ParentHash, nil)
+	if err != nil {
+		return true
+	}
+	return snap.enoughDistance(p.val)
+}
+
 // CalcDifficulty is the difficulty adjustment algorithm. It returns the difficulty
 // that a new block should have based on the previous blocks in the chain and the
 // current signer.

--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -244,6 +244,20 @@ func (s *Snapshot) inturn(validator common.Address) bool {
 	return validators[offset] == validator
 }
 
+func (s *Snapshot) enoughDistance(validator common.Address) bool {
+	idx := s.indexOfVal(validator)
+	if idx < 0 {
+		return true
+	}
+	validatorNum := int64(len(s.validators()))
+	offset := (int64(s.Number) + 1) % int64(validatorNum)
+	if int64(idx) >= offset {
+		return int64(idx)-offset >= validatorNum/2
+	} else {
+		return validatorNum+int64(idx)-offset >= validatorNum/2
+	}
+}
+
 func (s *Snapshot) indexOfVal(validator common.Address) int {
 	validators := s.validators()
 	for idx, val := range validators {


### PR DESCRIPTION
### Description
If the validators of BSC run prune state node, it will write state in period. However, the write operation will take more than 3 seconds, it may get the validator been slashed or the next validator will generate an empty block.

This PR is to fix this without running in archive mode.
### Rationale
What we introduce:
The validators are scheduled to generate blocks in order, it is safe to write when the validator still far from its  turn to generate blocks.


### Example
No

### Changes
The condition to write block state. No affect to data-seed

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
