### PR TITLE
Implementation of SHA3-256 FIPS 202 hash precompile and EcRecover Uncompressed public key precompile to integrate with ICON blockchain

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -31,6 +31,10 @@ import (
 
 	//lint:ignore SA1019 Needed for precompile
 	"golang.org/x/crypto/ripemd160"
+
+	//Needed for SHA3-256 FIPS202 implementation
+	"encoding/hex"
+	"golang.org/x/crypto/sha3"
 )
 
 // PrecompiledContract is the basic interface for native Go contracts. The implementation
@@ -78,6 +82,9 @@ var PrecompiledContractsIstanbul = map[common.Address]PrecompiledContract{
 
 	common.BytesToAddress([]byte{100}): &tmHeaderValidate{},
 	common.BytesToAddress([]byte{101}): &iavlMerkleProofValidate{},
+	//Precompiled contracts for sha3-256 FIPS202 & recover uncompressed public key
+	common.BytesToAddress([]byte{102}): &sha3fips{},
+	common.BytesToAddress([]byte{103}): &ecrecoverPublicKey{},
 }
 
 // RunPrecompiledContract runs and evaluates the output of a precompiled contract.
@@ -504,4 +511,58 @@ func (c *blake2F) Run(input []byte) ([]byte, error) {
 		binary.LittleEndian.PutUint64(output[offset:offset+8], h[i])
 	}
 	return output, nil
+}
+
+// SHA3-256 FIPS 202 standard implementation.
+type sha3fips struct{}
+
+// RequiredGas returns the gas required to execute the pre-compiled contract.
+//
+// This method does not require any overflow checking as the input size gas costs
+// required for anything significant is so high it's impossible to pay for.
+func (c *sha3fips) RequiredGas(input []byte) uint64 {
+	return uint64(len(input)+31)/32*params.Sha256PerWordGas + params.Sha256BaseGas
+}
+func (c *sha3fips) Run(input []byte) ([]byte, error) {
+	hexStr := common.Bytes2Hex(input)
+	pub, _ := hex.DecodeString(hexStr)
+	h := sha3.Sum256(pub[:])
+	return h[:], nil
+}
+
+// Uncompressed Public Key recovery implementation.
+type ecrecoverPublicKey struct{}
+
+func (c *ecrecoverPublicKey) RequiredGas(input []byte) uint64 {
+	return params.EcrecoverGas
+}
+
+func (c *ecrecoverPublicKey) Run(input []byte) ([]byte, error) {
+	const ecrecoverPublicKeyInputLength = 128
+
+	input = common.RightPadBytes(input, ecrecoverPublicKeyInputLength)
+	// "input" is (hash, v, r, s), each 32 bytes
+	// but for ecrecover we want (r, s, v)
+
+	r := new(big.Int).SetBytes(input[64:96])
+	s := new(big.Int).SetBytes(input[96:128])
+	v := input[63]
+
+	// tighter sig s values input homestead only apply to tx sigs
+	if !allZero(input[32:63]) || !crypto.ValidateSignatureValues(v, r, s, false) {
+		return nil, nil
+	}
+	// We must make sure not to modify the 'input', so placing the 'v' along with
+	// the signature needs to be done on a new allocation
+	sig := make([]byte, 65)
+	copy(sig, input[64:128])
+	sig[64] = v
+	// v needs to be at the end for libsecp256k1
+	pubKey, err := crypto.Ecrecover(input[:32], sig)
+	// make sure the public key is a valid one
+	if err != nil {
+		return nil, nil
+	}
+
+	return pubKey, nil
 }

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -661,3 +661,56 @@ func TestPrecompiledEcrecover(t *testing.T) {
 	}
 
 }
+
+
+
+
+// sha3fips  test vectors
+var sha3fipsTests = []precompiledTest{
+	{
+		input: "0448250ebe88d77e0a12bcf530fe6a2cf1ac176945638d309b840d631940c93b78c2bd6d16f227a8877e3f1604cd75b9c5a8ab0cac95174a8a0a0f8ea9e4c10bca",
+		expected: "c7647f7e251bf1bd70863c8693e93a4e77dd0c9a689073e987d51254317dc704",
+		name:     "sha3fip",
+	},
+	{
+		input: "1234",
+		expected: "19becdc0e8d6dd4aa2c9c2983dbb9c61956a8ade69b360d3e6019f0bcd5557a9",
+		name:     "sha3fip",
+	},
+}
+
+func TestPrecompiledSHA3fips(t *testing.T) {
+	
+	for _, test := range sha3fipsTests {
+		testPrecompiled("66", test, t)
+	}
+
+}
+
+
+// EcRecoverPublicKey test vectors
+var ecRecoverPublicKeyTests = []precompiledTest{
+	{
+		input: "c5d6c454e4d7a8e8a654f5ef96e8efe41d21a65b171b298925414aa3dc061e37" +
+			"0000000000000000000000000000000000000000000000000000000000000000" +
+			"4011de30c04302a2352400df3d1459d6d8799580dceb259f45db1d99243a8d0c" +
+			"64f548b7776cb93e37579b830fc3efce41e12e0958cda9f8c5fcad682c610795",
+		expected: "0448250ebe88d77e0a12bcf530fe6a2cf1ac176945638d309b840d631940c93b78c2bd6d16f227a8877e3f1604cd75b9c5a8ab0cac95174a8a0a0f8ea9e4c10bca",
+		name:     "Call ecrecoverPublicKey recoverable Key",
+	}, 
+	{
+		input: "c5d6c454e4d7a8e8a654f5ef96e8efe41d21a65b171b298925414aa3dc061e37" +
+			"000000000000000000000000000000000000000000000000000000000000001b" +
+			"4011de30c04302a2352400df3d1459d6d8799580dceb259f45db1d99243a8d0c" +
+			"64f548b7776cb93e37579b830fc3efce41e12e0958cda9f8c5fcad682c610795",
+		expected: "",
+		name:     "call ecrecoverPublicKey un-recoverable Key- Invalid 'v' parity",
+	},
+}
+ 
+func TestPrecompiledEcrecoverPublicKey(t *testing.T) {
+	for _, test := range ecRecoverPublicKeyTests {
+		testPrecompiled("67", test, t)
+	}
+
+}


### PR DESCRIPTION


### Description

- Implementation of SHA3-256 FIPS 202 hash precompile to integrate with ICON blockchain
- EcRecover Uncompressed public key precompile to integrate with ICON blockchain

### Rationale

- In order to validate the merkle tree data from ICON, the SHA3-256 hashing function is required because all of ICON blockchain's hash and transaction hash are created using the SHA3-256 hashing function
- It is needed to validate signatures of validators in ICON. Currently ICON uses a similar address building scheme to ethereum. ICON uses a part of the hash value of the public key. But we are using a different hash function, SHA3-256 FIPS.

### Example

Test cases done to check the input and output of the functions for the given parameters below

sha3fips
params
data : ‘0x0448250ebe88d77e0a12bcf530fe6a2cf1ac176945638d309b840d631940c93b78c2bd6d16f227a8877e3f1604cd75b9c5a8ab0cac95174a8a0a0f8ea9e4c10bca’
returns : ‘0xc7647f7e251bf1bd70863c8693e93a4e77dd0c9a689073e987d51254317dc704’

ecrecoverPublicKey
params
hash : ‘0xc5d6c454e4d7a8e8a654f5ef96e8efe41d21a65b171b298925414aa3dc061e37’
v : ‘0x00’
r : ‘0x4011de30c04302a2352400df3d1459d6d8799580dceb259f45db1d99243a8d0c’
s : ‘0x64f548b7776cb93e37579b830fc3efce41e12e0958cda9f8c5fcad682c610795’
returns : ‘0x0448250ebe88d77e0a12bcf530fe6a2cf1ac176945638d309b840d631940c93b78c2bd6d16f227a8877e3f1604cd75b9c5a8ab0cac95174a8a0a0f8ea9e4c10bca’


### Changes

Notable changes: 
* Added the new methods on to the contracts.go file 
* And the related testcases on to the contracts_test.go file

### Preflight checks

- [x] build passed (`make build`) - Passed
- [x] tests passed (`make test`) - Passed
- [x] manual transaction test passed - Passed

### Already reviewed by


### Related issues


