### PR TITLE
[R4R]add health check endpoint

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -47,6 +47,8 @@ import (
 	"github.com/tyler-smith/go-bip39"
 )
 
+const UnHealthyTimeout = 5 * time.Second
+
 // PublicEthereumAPI provides an API to access Ethereum related information.
 // It offers only methods that operate on public data that is freely available to anyone.
 type PublicEthereumAPI struct {
@@ -655,6 +657,13 @@ func (s *PublicBlockChainAPI) GetBlockByHash(ctx context.Context, hash common.Ha
 		return s.rpcMarshalBlock(block, true, fullTx)
 	}
 	return nil, err
+}
+
+func (s *PublicBlockChainAPI) Health() bool {
+	if rpc.RpcServingTimer != nil {
+		return rpc.RpcServingTimer.Percentile(0.75) < float64(UnHealthyTimeout)
+	}
+	return true
 }
 
 // GetUncleByBlockNumberAndIndex returns the uncle block for the given block hash and index. When fullTx is true

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -340,7 +340,7 @@ func (h *handler) handleCall(cp *callProc, msg *jsonrpcMessage) *jsonrpcMessage 
 		} else {
 			successfulRequestGauge.Inc(1)
 		}
-		rpcServingTimer.UpdateSince(start)
+		RpcServingTimer.UpdateSince(start)
 		newRPCRequestGauge(msg.Method).Inc(1)
 		newRPCServingTimer(msg.Method, answer.Error == nil).UpdateSince(start)
 	}

--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -26,7 +26,7 @@ var (
 	rpcRequestGauge        = metrics.NewRegisteredGauge("rpc/requests", nil)
 	successfulRequestGauge = metrics.NewRegisteredGauge("rpc/success", nil)
 	failedReqeustGauge     = metrics.NewRegisteredGauge("rpc/failure", nil)
-	rpcServingTimer        = metrics.NewRegisteredTimer("rpc/duration/all", nil)
+	RpcServingTimer        = metrics.NewRegisteredTimer("rpc/duration/all", nil)
 )
 
 func newRPCServingTimer(method string, valid bool) metrics.Timer {


### PR DESCRIPTION
### Description
We need a health check endpoint to detect whether the RPC func of a node is ok.



### Rationale
Decide to use the rpc latency as the health metrics.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
