### PR TITLE
[R4R]improve the performance of sentry nodes

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -69,6 +69,7 @@ var (
 		utils.ExternalSignerFlag,
 		utils.NoUSBFlag,
 		utils.DirectBroadcastFlag,
+		utils.SkipAnnounceTxFlag,
 		utils.RangeLimitFlag,
 		utils.SmartCardDaemonPathFlag,
 		utils.OverrideIstanbulFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -71,6 +71,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.KeyStoreDirFlag,
 			utils.NoUSBFlag,
 			utils.DirectBroadcastFlag,
+			utils.SkipAnnounceTxFlag,
 			utils.RangeLimitFlag,
 			utils.SmartCardDaemonPathFlag,
 			utils.NetworkIdFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -147,6 +147,10 @@ var (
 		Name:  "directbroadcast",
 		Usage: "Enable directly broadcast mined block to all peers",
 	}
+	SkipAnnounceTxFlag = cli.BoolFlag{
+		Name:  "skipAnnounceTx",
+		Usage: "Skip announce transactions to peers",
+	}
 	RangeLimitFlag = cli.BoolFlag{
 		Name:  "rangelimit",
 		Usage: "Enable 5000 blocks limit for range query",
@@ -1259,6 +1263,10 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	if ctx.GlobalIsSet(DirectBroadcastFlag.Name) {
 		cfg.DirectBroadcast = ctx.GlobalBool(DirectBroadcastFlag.Name)
 	}
+	if ctx.GlobalIsSet(SkipAnnounceTxFlag.Name) {
+		cfg.SkipAnnounceTx = ctx.GlobalBool(SkipAnnounceTxFlag.Name)
+	}
+
 	if ctx.GlobalIsSet(RangeLimitFlag.Name) {
 		cfg.RangeLimit = ctx.GlobalBool(RangeLimitFlag.Name)
 	}
@@ -1543,6 +1551,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	}
 	if ctx.GlobalIsSet(DirectBroadcastFlag.Name) {
 		cfg.DirectBroadcast = ctx.GlobalBool(DirectBroadcastFlag.Name)
+	}
+	if ctx.GlobalIsSet(SkipAnnounceTxFlag.Name) {
+		cfg.SkipAnnounceTx = ctx.GlobalBool(SkipAnnounceTxFlag.Name)
 	}
 	if ctx.GlobalIsSet(RangeLimitFlag.Name) {
 		cfg.RangeLimit = ctx.GlobalBool(RangeLimitFlag.Name)

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -21,11 +21,18 @@ import (
 	"math"
 	"math/big"
 	"sort"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 )
+
+var txSortedMapPool = sync.Pool{
+	New: func() interface{} {
+		return make(types.Transactions, 0, 100)
+	},
+}
 
 // nonceHeap is a heap.Interface implementation over 64bit unsigned integers for
 // retrieving sorted transactions from the possibly gapped future queue.
@@ -75,6 +82,9 @@ func (m *txSortedMap) Put(tx *types.Transaction) {
 	if m.items[nonce] == nil {
 		heap.Push(m.index, nonce)
 	}
+	if m.cache != nil {
+		txSortedMapPool.Put(m.cache)
+	}
 	m.items[nonce], m.cache = tx, nil
 }
 
@@ -116,7 +126,9 @@ func (m *txSortedMap) Filter(filter func(*types.Transaction) bool) types.Transac
 			*m.index = append(*m.index, nonce)
 		}
 		heap.Init(m.index)
-
+		if m.cache != nil {
+			txSortedMapPool.Put(m.cache)
+		}
 		m.cache = nil
 	}
 	return removed
@@ -163,6 +175,9 @@ func (m *txSortedMap) Remove(nonce uint64) bool {
 		}
 	}
 	delete(m.items, nonce)
+	if m.cache != nil {
+		txSortedMapPool.Put(m.cache)
+	}
 	m.cache = nil
 
 	return true
@@ -187,6 +202,9 @@ func (m *txSortedMap) Ready(start uint64) types.Transactions {
 		delete(m.items, next)
 		heap.Pop(m.index)
 	}
+	if m.cache != nil {
+		txSortedMapPool.Put(m.cache)
+	}
 	m.cache = nil
 
 	return ready
@@ -203,7 +221,13 @@ func (m *txSortedMap) Len() int {
 func (m *txSortedMap) Flatten() types.Transactions {
 	// If the sorting was not cached yet, create and cache it
 	if m.cache == nil {
-		m.cache = make(types.Transactions, 0, len(m.items))
+		cache := txSortedMapPool.Get()
+		if cache != nil {
+			m.cache = cache.(types.Transactions)
+			m.cache = m.cache[:0]
+		} else {
+			m.cache = make(types.Transactions, 0, len(m.items))
+		}
 		for _, tx := range m.items {
 			m.cache = append(m.cache, tx)
 		}
@@ -348,7 +372,7 @@ func (l *txList) Ready(start uint64) types.Transactions {
 
 // Len returns the length of the transaction list.
 func (l *txList) Len() int {
-	return l.txs.Len()
+	return len(l.txs.items)
 }
 
 // Empty returns whether the list of transactions is empty or not.

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1041,7 +1041,7 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 		// Nonces were reset, discard any events that became stale
 		for addr := range events {
 			events[addr].Forward(pool.pendingNonces.get(addr))
-			if events[addr].Len() == 0 {
+			if len(events[addr].items) == 0 {
 				delete(events, addr)
 			}
 		}
@@ -1246,7 +1246,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 func (pool *TxPool) truncatePending() {
 	pending := uint64(0)
 	for _, list := range pool.pending {
-		pending += uint64(list.Len())
+		pending += uint64(len(list.txs.items))
 	}
 	if pending <= pool.config.GlobalSlots {
 		return
@@ -1257,8 +1257,8 @@ func (pool *TxPool) truncatePending() {
 	spammers := prque.New(nil)
 	for addr, list := range pool.pending {
 		// Only evict transactions from high rollers
-		if !pool.locals.contains(addr) && uint64(list.Len()) > pool.config.AccountSlots {
-			spammers.Push(addr, int64(list.Len()))
+		if !pool.locals.contains(addr) && uint64(len(list.txs.items)) > pool.config.AccountSlots {
+			spammers.Push(addr, int64(len(list.txs.items)))
 		}
 	}
 	// Gradually drop transactions from offenders
@@ -1271,14 +1271,14 @@ func (pool *TxPool) truncatePending() {
 		// Equalize balances until all the same or below threshold
 		if len(offenders) > 1 {
 			// Calculate the equalization threshold for all current offenders
-			threshold := pool.pending[offender.(common.Address)].Len()
+			threshold := len(pool.pending[offender.(common.Address)].txs.items)
 
 			// Iteratively reduce all offenders until below limit or threshold reached
-			for pending > pool.config.GlobalSlots && pool.pending[offenders[len(offenders)-2]].Len() > threshold {
+			for pending > pool.config.GlobalSlots && len(pool.pending[offenders[len(offenders)-2]].txs.items) > threshold {
 				for i := 0; i < len(offenders)-1; i++ {
 					list := pool.pending[offenders[i]]
 
-					caps := list.Cap(list.Len() - 1)
+					caps := list.Cap(len(list.txs.items) - 1)
 					for _, tx := range caps {
 						// Drop the transaction from the global pools too
 						hash := tx.Hash()
@@ -1301,11 +1301,11 @@ func (pool *TxPool) truncatePending() {
 
 	// If still above threshold, reduce to limit or min allowance
 	if pending > pool.config.GlobalSlots && len(offenders) > 0 {
-		for pending > pool.config.GlobalSlots && uint64(pool.pending[offenders[len(offenders)-1]].Len()) > pool.config.AccountSlots {
+		for pending > pool.config.GlobalSlots && uint64(len(pool.pending[offenders[len(offenders)-1]].txs.items)) > pool.config.AccountSlots {
 			for _, addr := range offenders {
 				list := pool.pending[addr]
 
-				caps := list.Cap(list.Len() - 1)
+				caps := list.Cap(len(list.txs.items) - 1)
 				for _, tx := range caps {
 					// Drop the transaction from the global pools too
 					hash := tx.Hash()
@@ -1331,7 +1331,7 @@ func (pool *TxPool) truncatePending() {
 func (pool *TxPool) truncateQueue() {
 	queued := uint64(0)
 	for _, list := range pool.queue {
-		queued += uint64(list.Len())
+		queued += uint64(len(list.txs.items))
 	}
 	if queued <= pool.config.GlobalQueue {
 		return
@@ -1354,7 +1354,7 @@ func (pool *TxPool) truncateQueue() {
 		addresses = addresses[:len(addresses)-1]
 
 		// Drop all transactions if they are less than the overflow
-		if size := uint64(list.Len()); size <= drop {
+		if size := uint64(len(list.txs.items)); size <= drop {
 			for _, tx := range list.Flatten() {
 				pool.removeTx(tx.Hash(), true)
 			}
@@ -1407,7 +1407,7 @@ func (pool *TxPool) demoteUnexecutables() {
 			localGauge.Dec(int64(len(olds) + len(drops) + len(invalids)))
 		}
 		// If there's a gap in front, alert (should never happen) and postpone all transactions
-		if list.Len() > 0 && list.txs.Get(nonce) == nil {
+		if len(list.txs.items) > 0 && list.txs.Get(nonce) == nil {
 			gapped := list.Cap(0)
 			for _, tx := range gapped {
 				hash := tx.Hash()

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -213,7 +213,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	if checkpoint == nil {
 		checkpoint = params.TrustedCheckpoints[genesisHash]
 	}
-	if eth.protocolManager, err = NewProtocolManager(chainConfig, checkpoint, config.SyncMode, config.NetworkId, eth.eventMux, eth.txPool, eth.engine, eth.blockchain, chainDb, cacheLimit, config.Whitelist, config.DirectBroadcast); err != nil {
+	if eth.protocolManager, err = NewProtocolManager(chainConfig, checkpoint, config.SyncMode, config.NetworkId, eth.eventMux, eth.txPool, eth.engine, eth.blockchain, chainDb, cacheLimit, config.Whitelist, config.DirectBroadcast, config.SkipAnnounceTx); err != nil {
 		return nil, err
 	}
 

--- a/eth/config.go
+++ b/eth/config.go
@@ -107,6 +107,7 @@ type Config struct {
 	NoPruning       bool // Whether to disable pruning and flush everything to disk
 	NoPrefetch      bool // Whether to disable prefetching and only load state on demand
 	DirectBroadcast bool
+	SkipAnnounceTx  bool
 	RangeLimit      bool
 
 	// Whitelist of required block number -> hash values to accept

--- a/node/config.go
+++ b/node/config.go
@@ -98,6 +98,9 @@ type Config struct {
 	// DirectBroadcast enable directly broadcast mined block to all peers
 	DirectBroadcast bool `toml:",omitempty"`
 
+	// SkipAnnounceTx enable skip announce tx to peers
+	SkipAnnounceTx bool `toml:",omitempty"`
+
 	// RangeLimit enable 5000 blocks limit when handle range query
 	RangeLimit bool `toml:",omitempty"`
 

--- a/p2p/dial_test.go
+++ b/p2p/dial_test.go
@@ -47,9 +47,9 @@ func TestDialSchedDynDial(t *testing.T) {
 		// 9 nodes are discovered, but only 2 are dialed.
 		{
 			peersAdded: []*conn{
-				{flags: staticDialedConn, node: newNode(uintID(0x00), "")},
-				{flags: dynDialedConn, node: newNode(uintID(0x01), "")},
-				{flags: dynDialedConn, node: newNode(uintID(0x02), "")},
+				{flags: StaticDialedConn, node: newNode(uintID(0x00), "")},
+				{flags: DynDialedConn, node: newNode(uintID(0x01), "")},
+				{flags: DynDialedConn, node: newNode(uintID(0x02), "")},
 			},
 			discovered: []*enode.Node{
 				newNode(uintID(0x00), "127.0.0.1:30303"), // not dialed because already connected as static peer
@@ -165,8 +165,8 @@ func TestDialSchedStaticDial(t *testing.T) {
 		// aren't yet connected.
 		{
 			peersAdded: []*conn{
-				{flags: dynDialedConn, node: newNode(uintID(0x01), "127.0.0.1:30303")},
-				{flags: dynDialedConn, node: newNode(uintID(0x02), "127.0.0.2:30303")},
+				{flags: DynDialedConn, node: newNode(uintID(0x01), "127.0.0.1:30303")},
+				{flags: DynDialedConn, node: newNode(uintID(0x02), "127.0.0.2:30303")},
 			},
 			update: func(d *dialScheduler) {
 				// These two are not dialed because they're already connected
@@ -214,7 +214,7 @@ func TestDialSchedStaticDial(t *testing.T) {
 		// Only 0x01 is dialed.
 		{
 			peersAdded: []*conn{
-				{flags: inboundConn, node: newNode(uintID(0x07), "127.0.0.7:30303")},
+				{flags: InboundConn, node: newNode(uintID(0x07), "127.0.0.7:30303")},
 			},
 			peersRemoved: []enode.ID{
 				uintID(0x01),
@@ -286,8 +286,8 @@ func TestDialSchedManyStaticNodes(t *testing.T) {
 	runDialTest(t, config, []dialTestRound{
 		{
 			peersAdded: []*conn{
-				{flags: dynDialedConn, node: newNode(uintID(0xFFFE), "")},
-				{flags: dynDialedConn, node: newNode(uintID(0xFFFF), "")},
+				{flags: DynDialedConn, node: newNode(uintID(0xFFFE), "")},
+				{flags: DynDialedConn, node: newNode(uintID(0xFFFF), "")},
 			},
 			update: func(d *dialScheduler) {
 				for id := uint16(0); id < 2000; id++ {
@@ -428,7 +428,7 @@ func runDialTest(t *testing.T, config dialConfig, rounds []dialTestRound) {
 	// Set up the dialer. The setup function below runs on the dialTask
 	// goroutine and adds the peer.
 	var dialsched *dialScheduler
-	setup := func(fd net.Conn, f connFlag, node *enode.Node) error {
+	setup := func(fd net.Conn, f ConnFlag, node *enode.Node) error {
 		conn := &conn{flags: f, node: node}
 		dialsched.peerAdded(conn)
 		setupCh <- conn

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -143,6 +143,11 @@ func (p *Peer) Name() string {
 	return p.rw.name
 }
 
+// Name returns the node name that the remote node advertised.
+func (p *Peer) Flag() ConnFlag {
+	return p.rw.flags
+}
+
 // Caps returns the capabilities (supported subprotocols) of the remote peer.
 func (p *Peer) Caps() []Cap {
 	// TODO: maybe return copy
@@ -176,7 +181,7 @@ func (p *Peer) String() string {
 
 // Inbound returns true if the peer is an inbound connection
 func (p *Peer) Inbound() bool {
-	return p.rw.is(inboundConn)
+	return p.rw.is(InboundConn)
 }
 
 func newPeer(log log.Logger, conn *conn, protocols []Protocol) *Peer {
@@ -471,9 +476,9 @@ func (p *Peer) Info() *PeerInfo {
 	}
 	info.Network.LocalAddress = p.LocalAddr().String()
 	info.Network.RemoteAddress = p.RemoteAddr().String()
-	info.Network.Inbound = p.rw.is(inboundConn)
-	info.Network.Trusted = p.rw.is(trustedConn)
-	info.Network.Static = p.rw.is(staticDialedConn)
+	info.Network.Inbound = p.rw.is(InboundConn)
+	info.Network.Trusted = p.rw.is(TrustedConn)
+	info.Network.Static = p.rw.is(StaticDialedConn)
 
 	// Gather all the running protocol infos
 	for _, proto := range p.running {


### PR DESCRIPTION
### Description

for the sentry nodes, there is no need to announce tx to all peers, for bsc-dataseed, there are 400+ external peers, it will cost a lot of CPU resources

### Rationale

Add an option to decide announce tx or not for sentry nodes.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
