### PR TITLE
[R4R] make prune tool available

### DIFF
--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -378,7 +378,7 @@ func (t *Tree) Cap(root common.Hash, layers int) error {
 		}
 		rebloom(persisted.root)
 	}
-	log.Info("Snapshot capped", "root", root)
+	log.Debug("Snapshot capped", "root", root)
 	return nil
 }
 

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -204,6 +204,7 @@ func New(diskdb ethdb.KeyValueStore, triedb *trie.Database, cache int, root comm
 		snap.layers[head.Root()] = head
 		head = head.Parent()
 	}
+	log.Info("Snapshot loaded", "diskRoot", snap.diskRoot(), "root", root)
 	return snap, nil
 }
 
@@ -294,6 +295,7 @@ func (t *Tree) Update(blockRoot common.Hash, parentRoot common.Hash, destructs m
 	defer t.lock.Unlock()
 
 	t.layers[snap.root] = snap
+	log.Info("Snapshot updated", "blockRoot", blockRoot)
 	return nil
 }
 
@@ -376,6 +378,7 @@ func (t *Tree) Cap(root common.Hash, layers int) error {
 		}
 		rebloom(persisted.root)
 	}
+	log.Info("Snapshot capped", "root", root)
 	return nil
 }
 

--- a/les/peer.go
+++ b/les/peer.go
@@ -1043,9 +1043,6 @@ func (p *clientPeer) Handshake(td *big.Int, head common.Hash, headNum uint64, ge
 	if server.config.UltraLightOnlyAnnounce {
 		recentTx = txIndexDisabled
 	}
-	if recentTx != txIndexUnlimited && p.version < lpv4 {
-		return errors.New("Cannot serve old clients without a complete tx index")
-	}
 	// Note: clientPeer.headInfo should contain the last head announced to the client by us.
 	// The values announced in the handshake are dummy values for compatibility reasons and should be ignored.
 	p.headInfo = blockInfo{Hash: head, Number: headNum, Td: td}


### PR DESCRIPTION
### Description
The pruning tool is broken, and add layer 1 as the scope of the prune target.

### Rationale
Fix the prune tool

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
