### PR TITLE
[R4R]fix disk increase dramaticly issue

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -87,7 +87,7 @@ const (
 	maxFutureBlocks     = 256
 	maxTimeFutureBlocks = 30
 	badBlockLimit       = 10
-	TriesInMemory       = 1024
+	TriesInMemory       = 128
 
 	// BlockChainVersion ensures that an incompatible database forces a resync from scratch.
 	//


### PR DESCRIPTION
### Description
Fix the disk increase dramaticly issue

### Rationale
currently, 2.5G cache is not enough to hold the dirty cache of recent 1024 blocks.
![image](https://user-images.githubusercontent.com/7310198/117391252-2639c080-af22-11eb-82b0-dbeff36380b5.png)
It will trigger Cap to reduce the cache size.

Becuase dirty cache is written to disk.
![image](https://user-images.githubusercontent.com/7310198/117391279-32be1900-af22-11eb-9e68-1fa0eba33615.png)

`Dereference` here will not work..

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
