### PR TITLE
[R4R]fix the reorg routine stuck issue

### DIFF
--- a/eth/peer.go
+++ b/eth/peer.go
@@ -204,7 +204,7 @@ func (p *peer) broadcastTransactions() {
 			done = nil
 
 		case <-fail:
-			return
+			p.Log().Trace("BroadcastTransactions failed")
 
 		case <-p.term:
 			return


### PR DESCRIPTION
### Description

There is a dead lock issue in the Reorg routine of Transaction Pool implement of v1.0.7, which is already fixed in the latest geth v1.10.2 version. The randomly ungraceful shutdown connection between the upgrade version and current version trigger the deadlock, it is rarely happen . Why the connection is ungraceful shutdown is not very clear(connection upgraceful shutdown is very common actually), but we obviously need tolerate this.

### Rationale
https://github.com/ethereum/go-ethereum/blob/d8ff53dfb8a516f47db37dbc7fd7ad18a1e8a125/eth/protocols/eth/broadcast.go#L122

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
