### PR TITLE
[R4R]prepare release  v1.0.7-hf.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## v1.0.7-hf.2
+BUGFIX
+* [\#194](https://github.com/binance-chain/bsc/pull/194) bump btcd to v0.20.1-beta
+
 ## v1.0.7-hf.1
 BUGFIX
 * [\#190](https://github.com/binance-chain/bsc/pull/190) fix disk increase dramaticly

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ const (
 	VersionMajor = 1      // Major version component of the current release
 	VersionMinor = 0      // Minor version component of the current release
 	VersionPatch = 7      // Patch version component of the current release
-	VersionMeta  = "hf.1" // Version metadata to append to the version string
+	VersionMeta  = "hf.2" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
### Description

add a description of your changes here...

### Rationale
This is a maintained release.

BUGFIX
* [\#194](https://github.com/binance-chain/bsc/pull/194) bump btcd to v0.20.1-beta
### Example

add an example CLI or API response...


### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] manual transaction test passed

### Already reviewed by

### Related issues

