### PR TITLE
[R4R]use more aggressive write cache policy

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -868,7 +868,7 @@ func (p *Parlia) EnoughDistance(chain consensus.ChainReader, header *types.Heade
 	if err != nil {
 		return true
 	}
-	return snap.enoughDistance(p.val)
+	return snap.enoughDistance(p.val, header)
 }
 
 // CalcDifficulty is the difficulty adjustment algorithm. It returns the difficulty

--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -244,17 +244,23 @@ func (s *Snapshot) inturn(validator common.Address) bool {
 	return validators[offset] == validator
 }
 
-func (s *Snapshot) enoughDistance(validator common.Address) bool {
+func (s *Snapshot) enoughDistance(validator common.Address, header *types.Header) bool {
 	idx := s.indexOfVal(validator)
 	if idx < 0 {
 		return true
 	}
 	validatorNum := int64(len(s.validators()))
+	if validatorNum == 1 {
+		return true
+	}
+	if validator == header.Coinbase {
+		return false
+	}
 	offset := (int64(s.Number) + 1) % int64(validatorNum)
 	if int64(idx) >= offset {
-		return int64(idx)-offset >= validatorNum/2
+		return int64(idx)-offset >= validatorNum-2
 	} else {
-		return validatorNum+int64(idx)-offset >= validatorNum/2
+		return validatorNum+int64(idx)-offset >= validatorNum-2
 	}
 }
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -574,6 +574,9 @@ func (s *Ethereum) Stop() error {
 	close(s.closeBloomHandler)
 	s.txPool.Stop()
 	s.miner.Stop()
+	s.miner.Close()
+	// TODO this is a hotfix for https://github.com/ethereum/go-ethereum/issues/22892, need a better solution
+	time.Sleep(5 * time.Second)
 	s.blockchain.Stop()
 	s.engine.Close()
 	rawdb.PopUncleanShutdownMarker(s.chainDb)


### PR DESCRIPTION
### Description
Fix validator failed to produce a block occasionally.

### Rationale

The issue is caused by the persistence action, it takes around 48 seconds, so the validator do not have time to produce the block.
```
 t=2021-05-17T07:49:55+0000 lvl=info msg="Imported new chain segment"            blocks=1   txs=517   mgas=46.932   elapsed=218.339ms   mgasps=214.950  number=7,482,287 hash=0x2a7769438c9d64ce5192        41e99414e75890a37e568db6b24b7daf5dc3814158e8 dirty="2.00 GiB"

t=2021-05-17T07:50:41+0000 lvl=info msg="Persisted trie from memory database"   nodes=5,205,776 size="1.10 GiB"   time=43.360182272s gcnodes=47,892,102 gcsize="16.62 GiB" gctime=2m53.758774587s l        ivenodes=1,017,189 livesize="323.76 MiB"

t=2021-05-17T07:50:41+0000 lvl=info msg="Imported new chain segment"            blocks=1   txs=360   mgas=34.111   elapsed=43.523s     mgasps=0.784    number=7,482,288 hash=0x8aee890ea8e6ef39515c        e2f9cfc91966e04250c019a8f180f54ac4fe27613cfc dirty="439.11 MiB"
```

We change the distance logic, so that there is more time for a validator to persist cache.

### Example


### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
