### PR TITLE
[R3R]fix pending block null issue

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -184,19 +184,21 @@ func (miner *Miner) SetRecommitInterval(interval time.Duration) {
 // Pending returns the currently pending block and associated state.
 func (miner *Miner) Pending() (*types.Block, *state.StateDB) {
 	if miner.worker.isRunning() {
-		return miner.worker.pending()
-	} else {
-		// fallback to latest block
-		block := miner.worker.chain.CurrentBlock()
-		if block == nil {
-			return nil, nil
+		pendingBlock, pendingState := miner.worker.pending()
+		if pendingState != nil && pendingBlock != nil {
+			return pendingBlock, pendingState
 		}
-		stateDb, err := miner.worker.chain.StateAt(block.Root())
-		if err != nil {
-			return nil, nil
-		}
-		return block, stateDb
 	}
+	// fallback to latest block
+	block := miner.worker.chain.CurrentBlock()
+	if block == nil {
+		return nil, nil
+	}
+	stateDb, err := miner.worker.chain.StateAt(block.Root())
+	if err != nil {
+		return nil, nil
+	}
+	return block, stateDb
 }
 
 // PendingBlock returns the currently pending block.
@@ -206,11 +208,13 @@ func (miner *Miner) Pending() (*types.Block, *state.StateDB) {
 // change between multiple method calls
 func (miner *Miner) PendingBlock() *types.Block {
 	if miner.worker.isRunning() {
-		return miner.worker.pendingBlock()
-	} else {
-		// fallback to latest block
-		return miner.worker.chain.CurrentBlock()
+		pendingBlock := miner.worker.pendingBlock()
+		if pendingBlock != nil {
+			return pendingBlock
+		}
 	}
+	// fallback to latest block
+	return miner.worker.chain.CurrentBlock()
 }
 
 func (miner *Miner) SetEtherbase(addr common.Address) {


### PR DESCRIPTION
### Description
Fix https://github.com/binance-chain/bsc/issues/341

### Rationale
release v1.1.1-beta will not copy state anymore during proposing block to improve the performance, so that the pending block is null, this PR target to fix it.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
