### PR TITLE
fix syc failed on windows when prune

### DIFF
--- a/core/state/pruner/bloom.go
+++ b/core/state/pruner/bloom.go
@@ -90,7 +90,7 @@ func (bloom *stateBloom) Commit(filename, tempname string) error {
 		return err
 	}
 	// Ensure the file is synced to disk
-	f, err := os.Open(tempname)
+	f, err := os.OpenFile(tempname, os.O_RDWR, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description

After writing the bloom filter for the offline pruner, we opened the file read-only and synced it to disk. This ensures that the OS flushes all it's internal buffers before we start deleting data.

Whilst on Linux calling fsync on a read-only file works, it does not on Windows. 
This PR opens the file in read-write mode to work around this quirk.

Fixes https://github.com/ethereum/go-ethereum/issues/23364

### Rationale

Fixes https://github.com/ethereum/go-ethereum/issues/23364

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
