### PR TITLE
[R4R]prepare release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+## v1.1.1
+https://github.com/binance-chain/bsc/pull/350
+*[\#350](https://github.com/binance-chain/bsc/pull/350) flag: fix TriesInmemory specified but not work
+*[\#355](https://github.com/binance-chain/bsc/pull/355) miner should propose block on a proper fork
+*[\#358](https://github.com/binance-chain/bsc/pull/358) miner: fix null pending block
+*[\#360](https://github.com/binance-chain/bsc/pull/360) pruner: fix state bloom sync permission in Windows 
+*[\#366](https://github.com/binance-chain/bsc/pull/366) fix double close channel of subfetcher git reba
+
+
 ## v1.1.1-beta
 *[\#333](https://github.com/binance-chain/bsc/pull/333) improve block fetcher efficiency
 *[\#326](https://github.com/binance-chain/bsc/pull/326) eth/tracers: improve tracing performance

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1      // Major version component of the current release
-	VersionMinor = 1      // Minor version component of the current release
-	VersionPatch = 1      // Patch version component of the current release
-	VersionMeta  = "beta" // Version metadata to append to the version string
+	VersionMajor = 1  // Major version component of the current release
+	VersionMinor = 1  // Minor version component of the current release
+	VersionPatch = 1  // Patch version component of the current release
+	VersionMeta  = "" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
### Description

release v1.1.1

### Rationale

A stable release v1.1.1

### Example
None

### Changes
Minor fix:
*[\#350](https://github.com/binance-chain/bsc/pull/350) flag: fix TriesInmemory specified but not work
*[\#355](https://github.com/binance-chain/bsc/pull/355) miner should propose block on a proper fork
*[\#358](https://github.com/binance-chain/bsc/pull/358) miner: fix null pending block
*[\#360](https://github.com/binance-chain/bsc/pull/360) pruner: fix state bloom sync permission in Windows 

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
