### PR TITLE
fix: tracing system transactions failed due to wrong state

### DIFF
--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -19,11 +19,11 @@ package eth
 import (
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/consensus"
 	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -673,6 +673,15 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		}
 		// Execute the transaction and flush any traces to disk
 		vmenv := vm.NewEVM(vmctx, txContext, statedb, chainConfig, vmConf)
+		if posa, ok := api.backend.Engine().(consensus.PoSA); ok {
+			if isSystem, _ := posa.IsSystemTransaction(tx, block.Header()); isSystem {
+				balance := statedb.GetBalance(consensus.SystemAddress)
+				if balance.Cmp(common.Big0) > 0 {
+					statedb.SetBalance(consensus.SystemAddress, big.NewInt(0))
+					statedb.AddBalance(vmctx.Coinbase, balance)
+				}
+			}
+		}
 		statedb.Prepare(tx.Hash(), block.Hash(), i)
 		_, err = core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()))
 		if writer != nil {


### PR DESCRIPTION
### Description

This PR fixes getting the wrong state via `stateAtTransaction`

### Rationale

Due to Parlia consensus that BSC uses, `stateAtTransaction` should include additional checks.  
Before mining the block, validator adds to additional transactions to the end of the block, but before the transactions will be made the validator's balance is changing in [parlia.go](https://github.com/binance-chain/bsc/blob/master/consensus/parlia/parlia.go#L1010).  
While tracing the transaction via `debug_traceTransaction` the state is retrieved through [`StateAtTransaction`](https://github.com/binance-chain/bsc/blob/master/eth/tracers/api.go#L730) but there is no any checks whether the transaction is system during the generation of the state.  
This check is present in [`tracetx`](https://github.com/binance-chain/bsc/blob/03f7b318d9e19d0477bf3ffe6d6f85a681048dae/eth/tracers/api.go#L835) method, but as there are two system transactions at the end of the block this is not enough.   
For instance if validator had the balance, only to execute one system transaction, the trace of the second transaction will fail.
I have found more than 200 of transactions that fails while tracing them, but they are successful and valid transactions. Here is the list:
<details><summary> Transactions failing during tracing without this PR</summary>

```
0x91f8f8056af4242208a3eed09aaa3cf8a4a78b63ff6bdae503149dfbd0d68acf
0x75a899299bfad13c0d8e15692980f79fae0a1ded6885025b2fc7f1b4e4d1ef6c
0xe560c2fc4c816125d0bbb69c839011e82de8f0f2d4ab3fac038946119cfb300e
0x34b8a49d76f49e4584b553c3a02f81eac581c202c5edd45c182bc88c894d58ea
0x89c605022ba1b688cb77044bd335a683f124062ac19ab7754280191aa265cb04
0x91df8f6b8a7440456019eaf99aadb56e56954474eb09da5e68945685ea6a0f15
0x6a30fb1e955616f4213046c63e00e5e21f09f7a066ccabd5bcb2f64b1e0af201
0x69a8a718370f98202b5d4eb27f78a8cb22e1639b54d5a985bd9b2dd4e8bad47d
0x92ed50a167bcf8e93348bbbe3cdacb67540f2a9d0ca9775533e8c5af0b883b67
0xe14941f34dcb011c7a945643724af49721ba2fc0a64f666613eae9ca1de49c8a
0xa6b8c85e283dcbe6cfdac1a879b848161a245a69652a0b9b1e1c54c6bd8e26aa
0xc1a74db32849b0fc1db9546fe5971eb09ce2fb73b547424cb181f3c2a6ee00ab
0x0e597d24e9a9dc9c08e9b05c236d55affc1b1c2dbb9426cc1906b19802c3b7d9
0x6056f1f5842b719231cc1d4ef6a1d83e9fb50336e8050772522d995f06c4ad20
0x47e825ddec2450ab3800d7849883584f3311fe2c80bb3880ed97087363ae0cad
0x0ccbafa6e10cbf443b90ad2ab4c42d882807e86a72b3361bc3a51bd4ae8b8bf1
0x0326d033a568eb1c712b4fb2a216ddcf41db3a0ec9258b2f60da7d7e16308bf1
0xfa4b542aa9905ba63b744467761d0ca4cab6f415610b8b80c05546835d423714
0xbbb4c71c3afc9279069b0cd4559e7dc3fa45e32465a680224f4c1f0cd9baa643
0x3e57793b720017f7bf4d01af74f128ec78b136cdcc4e6a71841448f3df50a0e2
0x39ff818da5d5de25ab913ecce209f8ddadba1c929fea690b5be6e4c052360d65
0x3465af5b898cbdab9566129a951bfdf31807c1c46496e29f8959ccbdab445ba3
0x9930ca205b3d31aa4f33a6e657f9fcec0daf82c6e9393267ccd94c06bab20089
0xa25eaeb478937bb75c0950d45fb35541bd3e1f107c66fca85cd6e1f1a4542cac
0x952a7f0a645bbfe06cd61a74affb643a0df0813e8db62dae2da6f391938b3cc8
0x7615c5b0a3515acfb4001e598e74a13080fe36a3b17410f9c9e6b2599d1addf0
```
</details>

### Example

I queried the node with this PR and without it. The results that are in `successful` field below got from node built with this PR, others in `failed` got from the node built without this PR.

<details><summary>API Query</summary>

```json
[
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x91f8f8056af4242208a3eed09aaa3cf8a4a78b63ff6bdae503149dfbd0d68acf",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x75a899299bfad13c0d8e15692980f79fae0a1ded6885025b2fc7f1b4e4d1ef6c",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x75a899299bfad13c0d8e15692980f79fae0a1ded6885025b2fc7f1b4e4d1ef6c",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xe560c2fc4c816125d0bbb69c839011e82de8f0f2d4ab3fac038946119cfb300e",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x34b8a49d76f49e4584b553c3a02f81eac581c202c5edd45c182bc88c894d58ea",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x89c605022ba1b688cb77044bd335a683f124062ac19ab7754280191aa265cb04",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x91df8f6b8a7440456019eaf99aadb56e56954474eb09da5e68945685ea6a0f15",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x6a30fb1e955616f4213046c63e00e5e21f09f7a066ccabd5bcb2f64b1e0af201",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x69a8a718370f98202b5d4eb27f78a8cb22e1639b54d5a985bd9b2dd4e8bad47d",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x92ed50a167bcf8e93348bbbe3cdacb67540f2a9d0ca9775533e8c5af0b883b67",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xe14941f34dcb011c7a945643724af49721ba2fc0a64f666613eae9ca1de49c8a",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xa6b8c85e283dcbe6cfdac1a879b848161a245a69652a0b9b1e1c54c6bd8e26aa",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xc1a74db32849b0fc1db9546fe5971eb09ce2fb73b547424cb181f3c2a6ee00ab",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x0e597d24e9a9dc9c08e9b05c236d55affc1b1c2dbb9426cc1906b19802c3b7d9",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x6056f1f5842b719231cc1d4ef6a1d83e9fb50336e8050772522d995f06c4ad20",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x47e825ddec2450ab3800d7849883584f3311fe2c80bb3880ed97087363ae0cad",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x0ccbafa6e10cbf443b90ad2ab4c42d882807e86a72b3361bc3a51bd4ae8b8bf1",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x0326d033a568eb1c712b4fb2a216ddcf41db3a0ec9258b2f60da7d7e16308bf1",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xfa4b542aa9905ba63b744467761d0ca4cab6f415610b8b80c05546835d423714",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xbbb4c71c3afc9279069b0cd4559e7dc3fa45e32465a680224f4c1f0cd9baa643",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x3e57793b720017f7bf4d01af74f128ec78b136cdcc4e6a71841448f3df50a0e2",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x39ff818da5d5de25ab913ecce209f8ddadba1c929fea690b5be6e4c052360d65",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x3465af5b898cbdab9566129a951bfdf31807c1c46496e29f8959ccbdab445ba3",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x9930ca205b3d31aa4f33a6e657f9fcec0daf82c6e9393267ccd94c06bab20089",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xa25eaeb478937bb75c0950d45fb35541bd3e1f107c66fca85cd6e1f1a4542cac",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x952a7f0a645bbfe06cd61a74affb643a0df0813e8db62dae2da6f391938b3cc8",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x7615c5b0a3515acfb4001e598e74a13080fe36a3b17410f9c9e6b2599d1addf0",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xa6b8c85e283dcbe6cfdac1a879b848161a245a69652a0b9b1e1c54c6bd8e26aa",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x75a899299bfad13c0d8e15692980f79fae0a1ded6885025b2fc7f1b4e4d1ef6c",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xe560c2fc4c816125d0bbb69c839011e82de8f0f2d4ab3fac038946119cfb300e",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x91df8f6b8a7440456019eaf99aadb56e56954474eb09da5e68945685ea6a0f15",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x69a8a718370f98202b5d4eb27f78a8cb22e1639b54d5a985bd9b2dd4e8bad47d",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xe14941f34dcb011c7a945643724af49721ba2fc0a64f666613eae9ca1de49c8a",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x0326d033a568eb1c712b4fb2a216ddcf41db3a0ec9258b2f60da7d7e16308bf1",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x34b8a49d76f49e4584b553c3a02f81eac581c202c5edd45c182bc88c894d58ea",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xfa4b542aa9905ba63b744467761d0ca4cab6f415610b8b80c05546835d423714",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x3e57793b720017f7bf4d01af74f128ec78b136cdcc4e6a71841448f3df50a0e2",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x92ed50a167bcf8e93348bbbe3cdacb67540f2a9d0ca9775533e8c5af0b883b67",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x0ccbafa6e10cbf443b90ad2ab4c42d882807e86a72b3361bc3a51bd4ae8b8bf1",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x0e597d24e9a9dc9c08e9b05c236d55affc1b1c2dbb9426cc1906b19802c3b7d9",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x6a30fb1e955616f4213046c63e00e5e21f09f7a066ccabd5bcb2f64b1e0af201",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x47e825ddec2450ab3800d7849883584f3311fe2c80bb3880ed97087363ae0cad",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xc1a74db32849b0fc1db9546fe5971eb09ce2fb73b547424cb181f3c2a6ee00ab",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x39ff818da5d5de25ab913ecce209f8ddadba1c929fea690b5be6e4c052360d65",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x6056f1f5842b719231cc1d4ef6a1d83e9fb50336e8050772522d995f06c4ad20",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x9930ca205b3d31aa4f33a6e657f9fcec0daf82c6e9393267ccd94c06bab20089",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xbbb4c71c3afc9279069b0cd4559e7dc3fa45e32465a680224f4c1f0cd9baa643",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x3465af5b898cbdab9566129a951bfdf31807c1c46496e29f8959ccbdab445ba3",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xa25eaeb478937bb75c0950d45fb35541bd3e1f107c66fca85cd6e1f1a4542cac",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x7615c5b0a3515acfb4001e598e74a13080fe36a3b17410f9c9e6b2599d1addf0",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x952a7f0a645bbfe06cd61a74affb643a0df0813e8db62dae2da6f391938b3cc8",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xa6b8c85e283dcbe6cfdac1a879b848161a245a69652a0b9b1e1c54c6bd8e26aa",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x34b8a49d76f49e4584b553c3a02f81eac581c202c5edd45c182bc88c894d58ea",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x69a8a718370f98202b5d4eb27f78a8cb22e1639b54d5a985bd9b2dd4e8bad47d",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xe560c2fc4c816125d0bbb69c839011e82de8f0f2d4ab3fac038946119cfb300e",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x0326d033a568eb1c712b4fb2a216ddcf41db3a0ec9258b2f60da7d7e16308bf1",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xe14941f34dcb011c7a945643724af49721ba2fc0a64f666613eae9ca1de49c8a",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x92ed50a167bcf8e93348bbbe3cdacb67540f2a9d0ca9775533e8c5af0b883b67",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xfa4b542aa9905ba63b744467761d0ca4cab6f415610b8b80c05546835d423714",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x0e597d24e9a9dc9c08e9b05c236d55affc1b1c2dbb9426cc1906b19802c3b7d9",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x6a30fb1e955616f4213046c63e00e5e21f09f7a066ccabd5bcb2f64b1e0af201",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x47e825ddec2450ab3800d7849883584f3311fe2c80bb3880ed97087363ae0cad",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x3e57793b720017f7bf4d01af74f128ec78b136cdcc4e6a71841448f3df50a0e2",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x6056f1f5842b719231cc1d4ef6a1d83e9fb50336e8050772522d995f06c4ad20",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x0ccbafa6e10cbf443b90ad2ab4c42d882807e86a72b3361bc3a51bd4ae8b8bf1",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x3465af5b898cbdab9566129a951bfdf31807c1c46496e29f8959ccbdab445ba3",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x39ff818da5d5de25ab913ecce209f8ddadba1c929fea690b5be6e4c052360d65",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x9930ca205b3d31aa4f33a6e657f9fcec0daf82c6e9393267ccd94c06bab20089",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xbbb4c71c3afc9279069b0cd4559e7dc3fa45e32465a680224f4c1f0cd9baa643",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x7615c5b0a3515acfb4001e598e74a13080fe36a3b17410f9c9e6b2599d1addf0",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xa25eaeb478937bb75c0950d45fb35541bd3e1f107c66fca85cd6e1f1a4542cac",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x952a7f0a645bbfe06cd61a74affb643a0df0813e8db62dae2da6f391938b3cc8",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x34b8a49d76f49e4584b553c3a02f81eac581c202c5edd45c182bc88c894d58ea",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xa6b8c85e283dcbe6cfdac1a879b848161a245a69652a0b9b1e1c54c6bd8e26aa",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x47e825ddec2450ab3800d7849883584f3311fe2c80bb3880ed97087363ae0cad",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xe560c2fc4c816125d0bbb69c839011e82de8f0f2d4ab3fac038946119cfb300e",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x3e57793b720017f7bf4d01af74f128ec78b136cdcc4e6a71841448f3df50a0e2",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x0ccbafa6e10cbf443b90ad2ab4c42d882807e86a72b3361bc3a51bd4ae8b8bf1",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x92ed50a167bcf8e93348bbbe3cdacb67540f2a9d0ca9775533e8c5af0b883b67",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xe14941f34dcb011c7a945643724af49721ba2fc0a64f666613eae9ca1de49c8a",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xfa4b542aa9905ba63b744467761d0ca4cab6f415610b8b80c05546835d423714",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x6a30fb1e955616f4213046c63e00e5e21f09f7a066ccabd5bcb2f64b1e0af201",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x3465af5b898cbdab9566129a951bfdf31807c1c46496e29f8959ccbdab445ba3",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x34b8a49d76f49e4584b553c3a02f81eac581c202c5edd45c182bc88c894d58ea",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x6a30fb1e955616f4213046c63e00e5e21f09f7a066ccabd5bcb2f64b1e0af201",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x0ccbafa6e10cbf443b90ad2ab4c42d882807e86a72b3361bc3a51bd4ae8b8bf1",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xe14941f34dcb011c7a945643724af49721ba2fc0a64f666613eae9ca1de49c8a",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x6056f1f5842b719231cc1d4ef6a1d83e9fb50336e8050772522d995f06c4ad20",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x0e597d24e9a9dc9c08e9b05c236d55affc1b1c2dbb9426cc1906b19802c3b7d9",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xfa4b542aa9905ba63b744467761d0ca4cab6f415610b8b80c05546835d423714",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x92ed50a167bcf8e93348bbbe3cdacb67540f2a9d0ca9775533e8c5af0b883b67",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x9930ca205b3d31aa4f33a6e657f9fcec0daf82c6e9393267ccd94c06bab20089",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xa25eaeb478937bb75c0950d45fb35541bd3e1f107c66fca85cd6e1f1a4542cac",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0xa6b8c85e283dcbe6cfdac1a879b848161a245a69652a0b9b1e1c54c6bd8e26aa",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x3e57793b720017f7bf4d01af74f128ec78b136cdcc4e6a71841448f3df50a0e2",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x39ff818da5d5de25ab913ecce209f8ddadba1c929fea690b5be6e4c052360d65",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x3465af5b898cbdab9566129a951bfdf31807c1c46496e29f8959ccbdab445ba3",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x47e825ddec2450ab3800d7849883584f3311fe2c80bb3880ed97087363ae0cad",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x952a7f0a645bbfe06cd61a74affb643a0df0813e8db62dae2da6f391938b3cc8",
      {
        "tracer": "callTracer"
      }
    ]
  },
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "debug_traceTransaction",
    "params": [
      "0x7615c5b0a3515acfb4001e598e74a13080fe36a3b17410f9c9e6b2599d1addf0",
      {
        "tracer": "callTracer"
      }
    ]
  }
]
```
</details>

Below is the formatted API response as mentioned above, the response from the node built with this PR is in `successful`  
field, the response from the node built without this PR is in `failed` field of the json.
<details><summary>Formatted API Response</summary>

```json
{
  "0x91f8f8056af4242208a3eed09aaa3cf8a4a78b63ff6bdae503149dfbd0d68acf": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0x35e7a025f4da968de7e4d7e4004197917f4070f1",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x31b4a02579dd9d8",
        "gas": "0x7fffffffffffac53",
        "gasUsed": "0x42fe",
        "input": "0xf340fa0100000000000000000000000035e7a025f4da968de7e4d7e4004197917f4070f1",
        "output": "0x",
        "time": "132.88µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0x0e04d8d28d42bd0f6bd9bd5ee27b88053043711ad43b97687bc85a1a197a8b47 failed: insufficient funds for transfer: address 0x35E7a025f4da968De7e4D7E4004197917F4070F1"
      }
    }
  },
  "0x75a899299bfad13c0d8e15692980f79fae0a1ded6885025b2fc7f1b4e4d1ef6c": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0x35e7a025f4da968de7e4d7e4004197917f4070f1",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x4522593b8af7913",
        "gas": "0x7fffffffffffac53",
        "gasUsed": "0x42fe",
        "input": "0xf340fa0100000000000000000000000035e7a025f4da968de7e4d7e4004197917f4070f1",
        "output": "0x",
        "time": "122.47µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0xee50390e2763b244e9eb39038ad2549f57cea2723ac7b265272a08fe7e16ed1a failed: insufficient funds for transfer: address 0x35E7a025f4da968De7e4D7E4004197917F4070F1"
      }
    }
  },
  "0xe560c2fc4c816125d0bbb69c839011e82de8f0f2d4ab3fac038946119cfb300e": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0xd6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x3ec9436ca8a3dbd",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa01000000000000000000000000d6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "output": "0x",
        "time": "143.221µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0x27aec07ea63d5570a531b2a867d8239ff3b3b3601fd18abc13c975f51aa90c91 failed: insufficient funds for transfer: address 0xd6caA02BBebaEbB5d7e581e4B66559e635F805fF"
      }
    }
  },
  "0x34b8a49d76f49e4584b553c3a02f81eac581c202c5edd45c182bc88c894d58ea": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0x35e7a025f4da968de7e4d7e4004197917f4070f1",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x49354568ca1da4e",
        "gas": "0x7fffffffffffac53",
        "gasUsed": "0x42fe",
        "input": "0xf340fa0100000000000000000000000035e7a025f4da968de7e4d7e4004197917f4070f1",
        "output": "0x",
        "time": "130.93µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0xc772d5b69422b588645c11105860f6db66ba93b68a6cfc5148c92ac4deb24fd7 failed: insufficient funds for transfer: address 0x35E7a025f4da968De7e4D7E4004197917F4070F1"
      }
    }
  },
  "0x89c605022ba1b688cb77044bd335a683f124062ac19ab7754280191aa265cb04": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0x82012708dafc9e1b880fd083b32182b869be8e09",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x59013273f48fa6a",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa0100000000000000000000000082012708dafc9e1b880fd083b32182b869be8e09",
        "output": "0x",
        "time": "132.22µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0x968fd7f4fcccf6a0b4a9b771226d1b18eaad7a27a04bcd6af1d6ffbdac9ee70f failed: insufficient funds for transfer: address 0x82012708DAfC9E1B880fd083B32182B869bE8E09"
      }
    }
  },
  "0x91df8f6b8a7440456019eaf99aadb56e56954474eb09da5e68945685ea6a0f15": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0xd6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x8bd39392fa22006",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa01000000000000000000000000d6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "output": "0x",
        "time": "149.929µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0xb4e264b13609ca531fdcae45fa839d11a5f9849dbe6ffa6fc5f39f4beb27a18b failed: insufficient funds for transfer: address 0xd6caA02BBebaEbB5d7e581e4B66559e635F805fF"
      }
    }
  },
  "0x6a30fb1e955616f4213046c63e00e5e21f09f7a066ccabd5bcb2f64b1e0af201": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0xd6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0xb8c3e06823f05a8",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa01000000000000000000000000d6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "output": "0x",
        "time": "124.02µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0x03beb6ad9eca25866c4cdf4ef8dca635b499a49ab1f4c08e0236c575e52573e2 failed: insufficient funds for transfer: address 0xd6caA02BBebaEbB5d7e581e4B66559e635F805fF"
      }
    }
  },
  "0x69a8a718370f98202b5d4eb27f78a8cb22e1639b54d5a985bd9b2dd4e8bad47d": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0x82012708dafc9e1b880fd083b32182b869be8e09",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x7aac649a0d94e28",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa0100000000000000000000000082012708dafc9e1b880fd083b32182b869be8e09",
        "output": "0x",
        "time": "130.27µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0xf45358cf20722336e5cd78089f2d6f070da9942cea2043fbd108e5016b82e270 failed: insufficient funds for transfer: address 0x82012708DAfC9E1B880fd083B32182B869bE8E09"
      }
    }
  },
  "0x92ed50a167bcf8e93348bbbe3cdacb67540f2a9d0ca9775533e8c5af0b883b67": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0xd6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x79d01a93b6a1931",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa01000000000000000000000000d6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "output": "0x",
        "time": "120.34µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0x7f6e0f6898305486641637744324613a9896eb6beea8d2c28152f3e326f332ab failed: insufficient funds for transfer: address 0xd6caA02BBebaEbB5d7e581e4B66559e635F805fF"
      }
    }
  },
  "0xe14941f34dcb011c7a945643724af49721ba2fc0a64f666613eae9ca1de49c8a": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0xd6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x887879b0ecbebb3",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa01000000000000000000000000d6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "output": "0x",
        "time": "119.95µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0xe9922d3b8c12bf07932f74b827bcd68cb2201c43b1a7f1f130c06a911636397f failed: insufficient funds for transfer: address 0xd6caA02BBebaEbB5d7e581e4B66559e635F805fF"
      }
    }
  },
  "0xa6b8c85e283dcbe6cfdac1a879b848161a245a69652a0b9b1e1c54c6bd8e26aa": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0x82012708dafc9e1b880fd083b32182b869be8e09",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x3de78dbb7a7dfff",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa0100000000000000000000000082012708dafc9e1b880fd083b32182b869be8e09",
        "output": "0x",
        "time": "122.98µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0xc33ab53f25223fbd408df5864b21469ff5e7a8fdf385a76691ce7554a14139e2 failed: insufficient funds for transfer: address 0x82012708DAfC9E1B880fd083B32182B869bE8E09"
      }
    }
  },
  "0xc1a74db32849b0fc1db9546fe5971eb09ce2fb73b547424cb181f3c2a6ee00ab": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0xd6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x5cec9aa24d4f2e8",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa01000000000000000000000000d6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "output": "0x",
        "time": "119.22µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0x11a85062f1d8b192a5ce3d2e2f2a5c316733e58c37475edef2f350d58e9cd8d4 failed: insufficient funds for transfer: address 0xd6caA02BBebaEbB5d7e581e4B66559e635F805fF"
      }
    }
  },
  "0x0e597d24e9a9dc9c08e9b05c236d55affc1b1c2dbb9426cc1906b19802c3b7d9": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0x82012708dafc9e1b880fd083b32182b869be8e09",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x6692a2f2545f7b9",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa0100000000000000000000000082012708dafc9e1b880fd083b32182b869be8e09",
        "output": "0x",
        "time": "120µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0xdfca4b17da6a8a6d243828783a615fbc31f31de198eacbc030d056c84829be6f failed: insufficient funds for transfer: address 0x82012708DAfC9E1B880fd083B32182B869bE8E09"
      }
    }
  },
  "0x6056f1f5842b719231cc1d4ef6a1d83e9fb50336e8050772522d995f06c4ad20": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0xd6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x6b253ac49a5dd93",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa01000000000000000000000000d6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "output": "0x",
        "time": "124.409µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0x8743eddd03defdced46e7f621be8ebe465a588db813602d5e1788ea7ef835067 failed: insufficient funds for transfer: address 0xd6caA02BBebaEbB5d7e581e4B66559e635F805fF"
      }
    }
  },
  "0x47e825ddec2450ab3800d7849883584f3311fe2c80bb3880ed97087363ae0cad": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0xd6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x38e09439c8bdd4c",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa01000000000000000000000000d6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "output": "0x",
        "time": "121.93µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0xc9337da6ba79437af4c42133cc7eabe40e14bdc0964dd15fd78e698e34d98b3f failed: insufficient funds for transfer: address 0xd6caA02BBebaEbB5d7e581e4B66559e635F805fF"
      }
    }
  },
  "0x0ccbafa6e10cbf443b90ad2ab4c42d882807e86a72b3361bc3a51bd4ae8b8bf1": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0x68bf0b8b6fb4e317a0f9d6f03eaf8ce6675bc60d",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0xe2f768147db851a",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa0100000000000000000000000068bf0b8b6fb4e317a0f9d6f03eaf8ce6675bc60d",
        "output": "0x",
        "time": "119.31µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0xee87c08594525b9cac0891c078655124916be58eacf50d7808c7d6670059f496 failed: insufficient funds for transfer: address 0x68Bf0B8b6FB4E317a0f9D6F03eAF8CE6675BC60D"
      }
    }
  },
  "0x0326d033a568eb1c712b4fb2a216ddcf41db3a0ec9258b2f60da7d7e16308bf1": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0x68bf0b8b6fb4e317a0f9d6f03eaf8ce6675bc60d",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x69be1b9d52459d8",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa0100000000000000000000000068bf0b8b6fb4e317a0f9d6f03eaf8ce6675bc60d",
        "output": "0x",
        "time": "119.14µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0x49422d47821d73f7281252d43ee1a2145aab815b93de39550b1a407fd855e5cd failed: insufficient funds for transfer: address 0x68Bf0B8b6FB4E317a0f9D6F03eAF8CE6675BC60D"
      }
    }
  },
  "0xfa4b542aa9905ba63b744467761d0ca4cab6f415610b8b80c05546835d423714": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0x68bf0b8b6fb4e317a0f9d6f03eaf8ce6675bc60d",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x671740fdb1201c0",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa0100000000000000000000000068bf0b8b6fb4e317a0f9d6f03eaf8ce6675bc60d",
        "output": "0x",
        "time": "125.2µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0x911ee159de43b4bfcf790c279b624ffe05158e4add89345e44d6693a17c39920 failed: insufficient funds for transfer: address 0x68Bf0B8b6FB4E317a0f9D6F03eAF8CE6675BC60D"
      }
    }
  },
  "0xbbb4c71c3afc9279069b0cd4559e7dc3fa45e32465a680224f4c1f0cd9baa643": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0x82012708dafc9e1b880fd083b32182b869be8e09",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x85145af94796944",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa0100000000000000000000000082012708dafc9e1b880fd083b32182b869be8e09",
        "output": "0x",
        "time": "129.51µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0x810a9f391bd5b497596a717f1def682dcf0fdcc7b3c15727d9417810ee0884fe failed: insufficient funds for transfer: address 0x82012708DAfC9E1B880fd083B32182B869bE8E09"
      }
    }
  },
  "0x3e57793b720017f7bf4d01af74f128ec78b136cdcc4e6a71841448f3df50a0e2": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0xd6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x52a05b770fc8be6",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa01000000000000000000000000d6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "output": "0x",
        "time": "128.76µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0x81f54c3152fa3c761eb44c734c0b08c66fd885afa50369b6f2961c8cf6f118c3 failed: insufficient funds for transfer: address 0xd6caA02BBebaEbB5d7e581e4B66559e635F805fF"
      }
    }
  },
  "0x39ff818da5d5de25ab913ecce209f8ddadba1c929fea690b5be6e4c052360d65": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0xd6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x7b94c280b154d5c",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa01000000000000000000000000d6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "output": "0x",
        "time": "116.35µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0xf76248daf5ace1a7575ab9ca7d42cc92fc26d0c1173d8bbe42cc7b06e00f333d failed: insufficient funds for transfer: address 0xd6caA02BBebaEbB5d7e581e4B66559e635F805fF"
      }
    }
  },
  "0x3465af5b898cbdab9566129a951bfdf31807c1c46496e29f8959ccbdab445ba3": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0xd6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x625c063ceed27c0",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa01000000000000000000000000d6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "output": "0x",
        "time": "149.261µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0x72a02abfff3e85071b9c4dc1401de538899fc94b512405ec690b94246f97fafc failed: insufficient funds for transfer: address 0xd6caA02BBebaEbB5d7e581e4B66559e635F805fF"
      }
    }
  },
  "0x9930ca205b3d31aa4f33a6e657f9fcec0daf82c6e9393267ccd94c06bab20089": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0x68bf0b8b6fb4e317a0f9d6f03eaf8ce6675bc60d",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x80c40223440f575",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa0100000000000000000000000068bf0b8b6fb4e317a0f9d6f03eaf8ce6675bc60d",
        "output": "0x",
        "time": "136.17µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0x2e9d21987c2126bfdbc80e005705ec9f019ea1948ba597390fe0bc1c97116d36 failed: insufficient funds for transfer: address 0x68Bf0B8b6FB4E317a0f9D6F03eAF8CE6675BC60D"
      }
    }
  },
  "0xa25eaeb478937bb75c0950d45fb35541bd3e1f107c66fca85cd6e1f1a4542cac": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0x68bf0b8b6fb4e317a0f9d6f03eaf8ce6675bc60d",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x61f647bf3ebc35a",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa0100000000000000000000000068bf0b8b6fb4e317a0f9d6f03eaf8ce6675bc60d",
        "output": "0x",
        "time": "122.63µs"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0x9d11c4e2f5cee43973931deb56f1c0a96ba4c17066c3498348c1a4bbaca6a5b9 failed: insufficient funds for transfer: address 0x68Bf0B8b6FB4E317a0f9D6F03eAF8CE6675BC60D"
      }
    }
  },
  "0x952a7f0a645bbfe06cd61a74affb643a0df0813e8db62dae2da6f391938b3cc8": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0xd6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x32461c0eba2fe48",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa01000000000000000000000000d6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "output": "0x",
        "time": "13.682066ms"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0x7e8116b7c17ae9e97e5db120c387c9de7b918132ddac1d17ce5ff4cb3010e327 failed: insufficient funds for transfer: address 0xd6caA02BBebaEbB5d7e581e4B66559e635F805fF"
      }
    }
  },
  "0x7615c5b0a3515acfb4001e598e74a13080fe36a3b17410f9c9e6b2599d1addf0": {
    "successful": {
      "jsonrpc": "2.0",
      "id": 1,
      "result": {
        "type": "CALL",
        "from": "0xd6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "to": "0x0000000000000000000000000000000000001000",
        "value": "0x560523a2768e921",
        "gas": "0x7fffffffffffac47",
        "gasUsed": "0x42fe",
        "input": "0xf340fa01000000000000000000000000d6caa02bbebaebb5d7e581e4b66559e635f805ff",
        "output": "0x",
        "time": "20.959045ms"
      }
    },
    "failed": {
      "jsonrpc": "2.0",
      "id": 1,
      "error": {
        "code": -32000,
        "message": "transaction 0xb4c26733e3b20d6df39070aa104c7f1aca052388d1c7255e0a53bb25cb67c0a6 failed: insufficient funds for transfer: address 0xd6caA02BBebaEbB5d7e581e4B66559e635F805fF"
      }
    }
  }
}
```
</details>

### Changes

Notable changes: 
* Added the check of the consensus engine and act accordingly consensus rules while getting the state in [`stateAtTransaction` function](https://github.com/binance-chain/bsc/blob/master/eth/state_accessor.go), that prevents tracing system transactions from failure.

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] manual transaction test passed

### Already reviewed by

...

### Related issues

#373 #314 