### PR TITLE
ci pipeline for release page

### DIFF
--- a/.github/generate_change_log.sh
+++ b/.github/generate_change_log.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+checksum() {
+    echo $(sha256sum $@ | awk '{print $1}')
+}
+change_log_file="./CHANGELOG.md"
+version="## $@"
+version_prefix="## v"
+start=0
+CHANGE_LOG=""
+while read line; do
+    if [[ $line == *"$version"* ]]; then
+        start=1
+        continue
+    fi
+    if [[ $line == *"$version_prefix"* ]] && [ $start == 1 ]; then
+        break;
+    fi
+    if [ $start == 1 ] && [[ $line != "" ]]; then
+        CHANGE_LOG+="$line\n"
+    fi
+done < ${change_log_file}
+MAINNET_ZIP_SUM="$(checksum ./mainnet.zip)"
+TESTNET_ZIP_SUM="$(checksum ./testnet.zip)"
+LINUX_BIN_SUM="$(checksum ./linux/geth)"
+MAC_BIN_SUM="$(checksum ./macos/geth)"
+WINDOWS_BIN_SUM="$(checksum ./windows/geth.exe)"
+OUTPUT=$(cat <<-END
+## Changelog\n
+${CHANGE_LOG}\n
+## Assets\n
+|    Assets    | Sha256 Checksum  |\n
+| :-----------: |------------|\n
+| mainnet.zip | ${MAINNET_ZIP_SUM} |\n
+| testnet.zip | ${TESTNET_ZIP_SUM} |\n
+| geth_linux | ${LINUX_BIN_SUM} |\n
+| geth_mac  | ${MAC_BIN_SUM} |\n
+| geth_windows  | ${WINDOWS_BIN_SUM} |\n
+END
+)
+
+echo -e ${OUTPUT}

--- a/.github/release.env
+++ b/.github/release.env
@@ -1,0 +1,2 @@
+MAINNET_FILE_URL="https://github.com/binance-chain/bsc/releases/download/v1.1.2/mainnet.zip"
+TESTNET_FILE_URL="https://github.com/binance-chain/bsc/releases/download/v1.1.2/testnet.zip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,176 @@
+name: Release
+
+on:
+  push:
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+jobs:
+  build:
+    name: Build Release
+    strategy:
+      matrix:
+        go-version: [1.16.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      # ==============================
+      #       Linux/Macos/Windows Build
+      # ==============================
+
+      - name: Build Binary for ${{matrix.os}}
+        run: make geth
+
+      # ==============================
+      #       Upload artifacts
+      # ==============================
+
+      - name: Upload Linux Build
+        uses: actions/upload-artifact@v2
+        if: matrix.os == 'ubuntu-latest'
+        with:
+          name: linux
+          path: ./build/bin/geth
+
+      - name: Upload MacOS Build
+        uses: actions/upload-artifact@v2
+        if: matrix.os == 'macos-latest'
+        with:
+          name: macos
+          path: ./build/bin/geth
+      
+      - name: Upload Windows Build
+        uses: actions/upload-artifact@v2
+        if: matrix.os == 'windows-latest'
+        with:
+          name: windows
+          path: ./build/bin/geth.exe
+
+  release:
+    name: Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      # ==============================
+      #       Download artifacts
+      # ==============================
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: linux
+          path: ./linux
+      
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: macos
+          path: ./macos
+      
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: windows
+          path: ./windows
+      
+      - name: Download Config File
+        run: |
+          . ./.github/release.env
+          echo "mainnet.zip url: $MAINNET_FILE_URL"
+          echo "testnet.zip url: $TESTNET_FILE_URL"
+          curl -L $MAINNET_FILE_URL -o ./mainnet.zip
+          curl -L $TESTNET_FILE_URL -o ./testnet.zip
+
+      # ==============================
+      #       Create release
+      # ==============================
+      - name: Generate Change Log
+        id: changelog
+        run: |
+          chmod 755 ./.github/generate_change_log.sh
+          CHANGELOG=$(./.github/generate_change_log.sh ${{ env.RELEASE_VERSION}})
+
+          echo "CHANGELOG<<EOF" >> $GITHUB_ENV
+          echo "$CHANGELOG" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: |
+            ${{ env.CHANGELOG }}
+          draft: false
+          prerelease: false
+
+      # Check downloaded files
+      - run: ls
+
+      - name: Upload Release Asset - Linux
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./linux/geth
+          asset_name: geth_linux
+          asset_content_type: application/octet-stream
+      
+      - name: Upload Release Asset - MacOS
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./macos/geth
+          asset_name: geth_mac
+          asset_content_type: application/octet-stream
+      
+      - name: Upload Release Asset - Windows
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./windows/geth.exe
+          asset_name: geth_windows.exe
+          asset_content_type: application/octet-stream
+      
+      - name: Upload Release Asset - MAINNET.ZIP
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./mainnet.zip
+          asset_name: mainnet.zip
+          asset_content_type: application/zip
+      
+      - name: Upload Release Asset - TESTNET.ZIP
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./testnet.zip
+          asset_name: testnet.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
### Description

Publish new release page when the new tag was push

### Rationale

N/A

### Example

New workflow:
1. update changelog into `CHANGELOG.md`
2. update the version name of `params/version.go`
3. make a new tag from the `master` branch
4. push tag

*Notice*
Please make sure `CHANGELOG.md` contains the tag with format `## v...`(ex: ## v1.1.2)
And ci pipeline will get the content below the tag as release body.

*Addition*
If you want to change `mainnet.zip` or `testnet.zip`, please update the download URL to `.github/release.env` with the name `MAINNET_FILE_URL` and `TESTNET_FILE_URL`.

Example of a release page made by ci: https://github.com/j75689/bsc/releases/tag/v1.1.2

### Changes

Notable changes: 
* add `.github/generate_change_log.sh`
* add `.github/release.env`
* add `.github/workflows/release.yml`

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] manual transaction test passed

### Already reviewed by

N/A

### Related issues

N/A