### PR TITLE
fix: nil pointer issue (#388)

### DIFF
--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -174,17 +174,6 @@ func (sub *Subscription) Unsubscribe() {
 		// this ensures that the manager won't use the event channel which
 		// will probably be closed by the client asap after this method returns.
 		<-sub.Err()
-
-	drainLoop:
-		for {
-			select {
-			case <-sub.f.logs:
-			case <-sub.f.hashes:
-			case <-sub.f.headers:
-			default:
-				break drainLoop
-			}
-		}
 	})
 }
 


### PR DESCRIPTION
### Description
Please see #388 

### Rationale

This issue cause by https://github.com/binance-chain/bsc/pull/59
Now the deadlock issue fix by official https://github.com/ethereum/go-ethereum/pull/22178
So just need to revert https://github.com/binance-chain/bsc/pull/59. 


### Example

`go test -race ./eth/filters/...`
```
ok      github.com/ethereum/go-ethereum/eth/filters     6.639s
```

### Changes

#### Notable changes: 
- revert commit `3d3f9694a426eafc32640a643b5399a58209da1c`

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] manual transaction test passed

### Already reviewed by
N/A

### Related issues
#388 

