### PR TITLE
core/state/snapshot: fix typo

### DIFF
--- a/core/state/snapshot/iterator.go
+++ b/core/state/snapshot/iterator.go
@@ -385,7 +385,7 @@ func (it *diskStorageIterator) Hash() common.Hash {
 	return common.BytesToHash(it.it.Key()) // The prefix will be truncated
 }
 
-// Slot returns the raw strorage slot content the iterator is currently at.
+// Slot returns the raw storage slot content the iterator is currently at.
 func (it *diskStorageIterator) Slot() []byte {
 	return it.it.Value()
 }


### PR DESCRIPTION

### Description

fixed typo.


### Changes

Notable changes: 
* strorage -> storage

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
