### PR TITLE
[R4R]fix nil point in downloader

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -985,6 +985,10 @@ func (d *Downloader) findAncestorBinarySearch(p *peerConnection, mode SyncMode, 
 					break
 				}
 				header := d.lightchain.GetHeaderByHash(h) // Independent of sync mode, header surely exists
+				if header == nil {
+					p.log.Error("header not found", "number", header.Number, "hash", header.Hash(), "request", check)
+					return 0, fmt.Errorf("%w: header no found (%d)", errBadPeer, header.Number)
+				}
 				if header.Number.Uint64() != check {
 					p.log.Warn("Received non requested header", "number", header.Number, "hash", header.Hash(), "request", check)
 					return 0, fmt.Errorf("%w: non-requested header (%d)", errBadPeer, header.Number)


### PR DESCRIPTION
### Description

fix https://github.com/binance-chain/bsc/issues/404

### Rationale

The downloader need check whether header is nil or not before using it.
### Example

No
### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [ ] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
