### PR TITLE
core/state/snapshot: fix BAD BLOCK error when snapshot is generating …

### DIFF
--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -560,6 +560,12 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 		default:
 		}
 		if batch.ValueSize() > ethdb.IdealBatchSize || abort != nil {
+			if bytes.Compare(currentLocation, dl.genMarker) < 0 {
+				log.Error("Snapshot generator went backwards",
+					"currentLocation", fmt.Sprintf("%x", currentLocation),
+					"genMarker", fmt.Sprintf("%x", dl.genMarker))
+			}
+
 			// Flush out the batch anyway no matter it's empty or not.
 			// It's possible that all the states are recovered and the
 			// generation indeed makes progress.
@@ -634,8 +640,14 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 			stats.storage += common.StorageSize(1 + common.HashLength + dataLen)
 			stats.accounts++
 		}
+		marker := accountHash[:]
+		// If the snap generation goes here after interrupted, genMarker may go backward
+		// when last genMarker is consisted of accountHash and storageHash
+		if accMarker != nil && bytes.Equal(marker, accMarker) && len(dl.genMarker) > common.HashLength {
+			marker = dl.genMarker[:]
+		}
 		// If we've exceeded our batch allowance or termination was requested, flush to disk
-		if err := checkAndFlush(accountHash[:]); err != nil {
+		if err := checkAndFlush(marker); err != nil {
 			return err
 		}
 		// If the iterated account is the contract, create a further loop to

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1028,8 +1028,8 @@ func (d *Downloader) findAncestorBinarySearch(p *peerConnection, mode SyncMode, 
 				}
 				header := d.lightchain.GetHeaderByHash(h) // Independent of sync mode, header surely exists
 				if header == nil {
-					p.log.Error("header not found", "number", header.Number, "hash", header.Hash(), "request", check)
-					return 0, fmt.Errorf("%w: header no found (%d)", errBadPeer, header.Number)
+					p.log.Error("header not found", "hash", h, "request", check)
+					return 0, fmt.Errorf("%w: header no found (%s)", errBadPeer, h)
 				}
 				if header.Number.Uint64() != check {
 					p.log.Warn("Received non requested header", "number", header.Number, "hash", header.Hash(), "request", check)


### PR DESCRIPTION
…(#23635)

* core/state/snapshot: fix BAD BLOCK error when snapshot is generating

* core/state/snapshot: alternative fix for the snapshot generator

* add comments and minor update

Co-authored-by: Martin Holst Swende <martin@swende.se>

### Description
fix BAD BLOCK error when snapshot is generating, cherry-picked the commit of go-ethereum: https://github.com/ethereum/go-ethereum/commit/312e02bca9e7968df41da3caa76295901bf74eb0


### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [ ] manual transaction test passed

### Related issues

https://github.com/ethereum/go-ethereum/pull/23635
