### PR TITLE
[R4R]fix prefetcher related bugs

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -144,13 +144,15 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.StateD
 			validateRes <- tmpFunc()
 		}()
 	}
+
+	var err error
 	for i := 0; i < len(validateFuns); i++ {
 		r := <-validateRes
-		if r != nil {
-			return r
+		if r != nil && err == nil {
+			err = r
 		}
 	}
-	return nil
+	return err
 }
 
 // CalcGasLimit computes the gas limit of the next block after parent. It aims

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -958,6 +958,7 @@ func (s *StateDB) Finalise(deleteEmptyObjects bool) {
 // goes into transaction receipts.
 func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 	if s.lightProcessed {
+		s.StopPrefetcher()
 		return s.trie.Hash()
 	}
 	// Finalise all the dirty storage states and write them into the tries


### PR DESCRIPTION
### Description

1.Fix panic in trie_prefetcher close
2.Fix trie_prefetcher abortLoop goroutine leak 

### Rationale

1.In ValidateState, there are three goroutines running concurrently, if the previous one return error, the upper caller function InsertChain would return and call it's defer function to close prefetcher, while the IntermediateRoot goroutine still run and when it done call its defer function to close prefetcher, this time the prefetcher is nil, so it will trigger a panic. So we should wait all the goroutines done in ValidateState to avoid this panic.
2.In InsertChain, if we enable diffsync, and insert two more blocks here, then all the blocks except the last one wound't do call StopPrefetcher, so these blocks' abortLoop goroutine will leak. So we should do the StopPrefetcher in IntermediateRoot to avoid this leak. 

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] manual transaction test passed

### Already reviewed by

...

### Related issues

#477 