### PR TITLE
[R4R] improve the protocol details of Diff sync

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -444,8 +444,8 @@ var (
 	}
 	DiffBlockFlag = cli.Uint64Flag{
 		Name:  "diffblock",
-		Usage: "The number of blocks should be persisted in db (default = 864000 )",
-		Value: uint64(864000),
+		Usage: "The number of blocks should be persisted in db (default = 86400)",
+		Value: uint64(86400),
 	}
 	// Miner settings
 	MiningEnabledFlag = cli.BoolFlag{

--- a/core/blockchain_diff_test.go
+++ b/core/blockchain_diff_test.go
@@ -322,7 +322,7 @@ func TestPruneDiffLayer(t *testing.T) {
 	if len(fullBackend.chain.diffNumToBlockHashes) != maxDiffForkDist {
 		t.Error("unexpected size of diffNumToBlockHashes")
 	}
-	if len(fullBackend.chain.diffPeersToDiffHashes) != 2 {
+	if len(fullBackend.chain.diffPeersToDiffHashes) != 1 {
 		t.Error("unexpected size of diffPeersToDiffHashes")
 	}
 	if len(fullBackend.chain.blockHashToDiffLayers) != maxDiffForkDist {

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -53,6 +53,9 @@ var (
 	ttlScaling       = 3                // Constant scaling factor for RTT -> TTL conversion
 	ttlLimit         = time.Minute      // Maximum TTL allowance to prevent reaching crazy timeouts
 
+	diffFetchTick  = 10 * time.Millisecond
+	diffFetchLimit = 5
+
 	qosTuningPeers   = 5    // Number of peers to tune based on (best peers)
 	qosConfidenceCap = 10   // Number of peers above which not to modify RTT confidence
 	qosTuningImpact  = 0.25 // Impact that a new tuning target has on the previous value
@@ -161,10 +164,10 @@ type Downloader struct {
 	quitLock sync.Mutex    // Lock to prevent double closes
 
 	// Testing hooks
-	syncInitHook     func(uint64, uint64)                  // Method to call upon initiating a new sync run
-	bodyFetchHook    func([]*types.Header, ...interface{}) // Method to call upon starting a block body fetch
-	receiptFetchHook func([]*types.Header, ...interface{}) // Method to call upon starting a receipt fetch
-	chainInsertHook  func([]*fetchResult)                  // Method to call upon inserting a chain of blocks (possibly in multiple invocations)
+	syncInitHook     func(uint64, uint64)                // Method to call upon initiating a new sync run
+	bodyFetchHook    func([]*types.Header)               // Method to call upon starting a block body fetch
+	receiptFetchHook func([]*types.Header)               // Method to call upon starting a receipt fetch
+	chainInsertHook  func([]*fetchResult, chan struct{}) // Method to call upon inserting a chain of blocks (possibly in multiple invocations)
 }
 
 // LightChain encapsulates functions required to synchronise a light chain.
@@ -232,27 +235,35 @@ type IPeerSet interface {
 
 func EnableDiffFetchOp(peers IPeerSet) DownloadOption {
 	return func(dl *Downloader) *Downloader {
-		var hook = func(headers []*types.Header, args ...interface{}) {
-			if len(args) < 2 {
-				return
-			}
-			peerID, ok := args[1].(string)
-			if !ok {
-				return
-			}
-			mode, ok := args[0].(SyncMode)
-			if !ok {
-				return
-			}
-			if ep := peers.GetDiffPeer(peerID); mode == FullSync && ep != nil {
-				hashes := make([]common.Hash, 0, len(headers))
-				for _, header := range headers {
-					hashes = append(hashes, header.Hash())
-				}
-				ep.RequestDiffLayers(hashes)
+		var hook = func(results []*fetchResult, stop chan struct{}) {
+			if dl.getMode() == FullSync {
+				go func() {
+					ticker := time.NewTicker(diffFetchTick)
+					defer ticker.Stop()
+					for _, r := range results {
+					Wait:
+						for {
+							select {
+							case <-stop:
+								return
+							case <-ticker.C:
+								if dl.blockchain.CurrentHeader().Number.Int64()+int64(diffFetchLimit) > r.Header.Number.Int64() {
+									break Wait
+								}
+							}
+						}
+						if ep := peers.GetDiffPeer(r.pid); ep != nil {
+							// It turns out a diff layer is 5x larger than block, we just request one diffLayer each time
+							err := ep.RequestDiffLayers([]common.Hash{r.Header.Hash()})
+							if err != nil {
+								return
+							}
+						}
+					}
+				}()
 			}
 		}
-		dl.bodyFetchHook = hook
+		dl.chainInsertHook = hook
 		return dl
 	}
 }
@@ -1405,7 +1416,7 @@ func (d *Downloader) fetchReceipts(from uint64) error {
 //  - kind:        textual label of the type being downloaded to display in log messages
 func (d *Downloader) fetchParts(deliveryCh chan dataPack, deliver func(dataPack) (int, error), wakeCh chan bool,
 	expire func() map[string]int, pending func() int, inFlight func() bool, reserve func(*peerConnection, int) (*fetchRequest, bool, bool),
-	fetchHook func([]*types.Header, ...interface{}), fetch func(*peerConnection, *fetchRequest) error, cancel func(*fetchRequest), capacity func(*peerConnection) int,
+	fetchHook func([]*types.Header), fetch func(*peerConnection, *fetchRequest) error, cancel func(*fetchRequest), capacity func(*peerConnection) int,
 	idle func() ([]*peerConnection, int), setIdle func(*peerConnection, int, time.Time), kind string) error {
 
 	// Create a ticker to detect expired retrieval tasks
@@ -1554,7 +1565,7 @@ func (d *Downloader) fetchParts(deliveryCh chan dataPack, deliver func(dataPack)
 				}
 				// Fetch the chunk and make sure any errors return the hashes to the queue
 				if fetchHook != nil {
-					fetchHook(request.Headers, d.getMode(), peer.id)
+					fetchHook(request.Headers)
 				}
 				if err := fetch(peer, request); err != nil {
 					// Although we could try and make an attempt to fix this, this error really
@@ -1759,12 +1770,15 @@ func (d *Downloader) processFullSyncContent() error {
 		if len(results) == 0 {
 			return nil
 		}
+		stop := make(chan struct{})
 		if d.chainInsertHook != nil {
-			d.chainInsertHook(results)
+			d.chainInsertHook(results, stop)
 		}
 		if err := d.importBlockResults(results); err != nil {
+			close(stop)
 			return err
 		}
+		close(stop)
 	}
 }
 
@@ -1850,7 +1864,7 @@ func (d *Downloader) processFastSyncContent() error {
 			}
 		}
 		if d.chainInsertHook != nil {
-			d.chainInsertHook(results)
+			d.chainInsertHook(results, nil)
 		}
 		// If we haven't downloaded the pivot block yet, check pivot staleness
 		// notifications from the header downloader

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -565,7 +565,7 @@ func testThrottling(t *testing.T, protocol uint, mode SyncMode) {
 
 	// Wrap the importer to allow stepping
 	blocked, proceed := uint32(0), make(chan struct{})
-	tester.downloader.chainInsertHook = func(results []*fetchResult) {
+	tester.downloader.chainInsertHook = func(results []*fetchResult, _ chan struct{}) {
 		atomic.StoreUint32(&blocked, uint32(len(results)))
 		<-proceed
 	}
@@ -921,10 +921,10 @@ func testEmptyShortCircuit(t *testing.T, protocol uint, mode SyncMode) {
 
 	// Instrument the downloader to signal body requests
 	bodiesHave, receiptsHave := int32(0), int32(0)
-	tester.downloader.bodyFetchHook = func(headers []*types.Header, _ ...interface{}) {
+	tester.downloader.bodyFetchHook = func(headers []*types.Header) {
 		atomic.AddInt32(&bodiesHave, int32(len(headers)))
 	}
-	tester.downloader.receiptFetchHook = func(headers []*types.Header, _ ...interface{}) {
+	tester.downloader.receiptFetchHook = func(headers []*types.Header) {
 		atomic.AddInt32(&receiptsHave, int32(len(headers)))
 	}
 	// Synchronise with the peer and make sure all blocks were retrieved

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -63,6 +63,7 @@ type fetchRequest struct {
 // all outstanding pieces complete and the result as a whole can be processed.
 type fetchResult struct {
 	pending int32 // Flag telling what deliveries are outstanding
+	pid     string
 
 	Header       *types.Header
 	Uncles       []*types.Header
@@ -70,9 +71,10 @@ type fetchResult struct {
 	Receipts     types.Receipts
 }
 
-func newFetchResult(header *types.Header, fastSync bool) *fetchResult {
+func newFetchResult(header *types.Header, fastSync bool, pid string) *fetchResult {
 	item := &fetchResult{
 		Header: header,
+		pid:    pid,
 	}
 	if !header.EmptyBody() {
 		item.pending |= (1 << bodyType)
@@ -503,7 +505,7 @@ func (q *queue) reserveHeaders(p *peerConnection, count int, taskPool map[common
 		// we can ask the resultcache if this header is within the
 		// "prioritized" segment of blocks. If it is not, we need to throttle
 
-		stale, throttle, item, err := q.resultCache.AddFetch(header, q.mode == FastSync)
+		stale, throttle, item, err := q.resultCache.AddFetch(header, q.mode == FastSync, p.id)
 		if stale {
 			// Don't put back in the task queue, this item has already been
 			// delivered upstream

--- a/eth/downloader/resultstore.go
+++ b/eth/downloader/resultstore.go
@@ -75,7 +75,7 @@ func (r *resultStore) SetThrottleThreshold(threshold uint64) uint64 {
 //   throttled - if true, the store is at capacity, this particular header is not prio now
 //   item      - the result to store data into
 //   err       - any error that occurred
-func (r *resultStore) AddFetch(header *types.Header, fastSync bool) (stale, throttled bool, item *fetchResult, err error) {
+func (r *resultStore) AddFetch(header *types.Header, fastSync bool, pid string) (stale, throttled bool, item *fetchResult, err error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
@@ -85,7 +85,7 @@ func (r *resultStore) AddFetch(header *types.Header, fastSync bool) (stale, thro
 		return stale, throttled, item, err
 	}
 	if item == nil {
-		item = newFetchResult(header, fastSync)
+		item = newFetchResult(header, fastSync, pid)
 		r.items[index] = item
 	}
 	return stale, throttled, item, err

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -80,7 +80,7 @@ var Defaults = Config{
 	TrieTimeout:             60 * time.Minute,
 	TriesInMemory:           128,
 	SnapshotCache:           102,
-	DiffBlock:               uint64(864000),
+	DiffBlock:               uint64(86400),
 	Miner: miner.Config{
 		GasFloor:      8000000,
 		GasCeil:       8000000,

--- a/eth/handler_diff.go
+++ b/eth/handler_diff.go
@@ -47,7 +47,6 @@ func (h *diffHandler) RunPeer(peer *diff.Peer, hand diff.Handler) error {
 		ps.lock.Unlock()
 		return err
 	}
-	defer h.chain.RemoveDiffPeer(peer.ID())
 	return (*handler)(h).runDiffExtension(peer, hand)
 }
 

--- a/eth/protocols/diff/handler.go
+++ b/eth/protocols/diff/handler.go
@@ -17,7 +17,7 @@ const (
 	softResponseLimit = 2 * 1024 * 1024
 
 	// maxDiffLayerServe is the maximum number of diff layers to serve.
-	maxDiffLayerServe = 1024
+	maxDiffLayerServe = 128
 )
 
 var requestTracker = NewTracker(time.Minute)


### PR DESCRIPTION
### Description
This pr focus on the detailed improvement of diff sync.

### Rationale
The diff sync protocol does not behave well as we expected:
1. A peer gets less than 50% chance to diff sync.
2. A peer may receive duplicated diff layer.
3. The diff layer cache may pop recent difflayer.
4. Open too many files issue when enable `persist diff` 
5. The received difflayers maybe dropped once disconnected with the peer.

### Example
No

### Changes

No



