### PR TITLE
get diff accounts by replaying block when diff layer not found

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1011,7 +1011,7 @@ func (bc *BlockChain) GetDiffAccounts(blockHash common.Hash) ([]common.Address, 
 
 	if diffLayer == nil {
 		if header.TxHash != types.EmptyRootHash {
-			return nil, fmt.Errorf("no diff layer found")
+			return nil, ErrDiffLayerNotFound
 		}
 
 		return nil, nil

--- a/core/error.go
+++ b/core/error.go
@@ -31,6 +31,9 @@ var (
 
 	// ErrNoGenesis is returned when there is no Genesis Block.
 	ErrNoGenesis = errors.New("genesis not found in chain")
+
+	// ErrDiffLayerNotFound is returned when diff layer not found.
+	ErrDiffLayerNotFound = errors.New("diff layer not found")
 )
 
 // List of evm-call-message pre-checking errors. All state transition messages will

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1493,3 +1493,11 @@ func (s *StateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addre
 	}
 	return s.accessList.Contains(addr, slot)
 }
+
+func (s *StateDB) GetDirtyAccounts() []common.Address {
+	accounts := make([]common.Address, 0, len(s.stateObjectsDirty))
+	for account := range s.stateObjectsDirty {
+		accounts = append(accounts, account)
+	}
+	return accounts
+}


### PR DESCRIPTION
Signed-off-by: Keefe-Liu <bianze.kernel@gmail.com>

### Description

Get block's diff accounts by replaying block when diff layer not found.

### Rationale

The diff layer just can cache for a few days, when there is no diff layer, the eth_getDiffAccounts API couldn't work, in this case we should replay the block and get the diff accounts, it may slow but i can work right.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
