### PR TITLE
[R4R]offline block prune

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ profile.cov
 
 **/yarn-error.log
 cmd/geth/node/
+cmd/geth/__debug_bin

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ profile.cov
 /dashboard/assets/package-lock.json
 
 **/yarn-error.log
+cmd/geth/node/

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -458,7 +458,7 @@ func importPreimages(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, false)
+	db := utils.MakeChainDatabase(ctx, stack, false, false)
 	start := time.Now()
 
 	if err := utils.ImportPreimages(db, ctx.Args().First()); err != nil {
@@ -477,7 +477,7 @@ func exportPreimages(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true)
+	db := utils.MakeChainDatabase(ctx, stack, true, false)
 	start := time.Now()
 
 	if err := utils.ExportPreimages(db, ctx.Args().First()); err != nil {
@@ -491,7 +491,7 @@ func dump(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true)
+	db := utils.MakeChainDatabase(ctx, stack, true, false)
 	for _, arg := range ctx.Args() {
 		var header *types.Header
 		if hashish(arg) {

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -458,7 +458,7 @@ func importPreimages(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, false, false, false)
+	db := utils.MakeChainDatabase(ctx, stack, false, false)
 	start := time.Now()
 
 	if err := utils.ImportPreimages(db, ctx.Args().First()); err != nil {
@@ -477,7 +477,7 @@ func exportPreimages(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, false)
 	start := time.Now()
 
 	if err := utils.ExportPreimages(db, ctx.Args().First()); err != nil {
@@ -491,7 +491,7 @@ func dump(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, false)
 	for _, arg := range ctx.Args() {
 		var header *types.Header
 		if hashish(arg) {

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -458,7 +458,7 @@ func importPreimages(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, false, false)
+	db := utils.MakeChainDatabase(ctx, stack, false, false, false)
 	start := time.Now()
 
 	if err := utils.ImportPreimages(db, ctx.Args().First()); err != nil {
@@ -477,7 +477,7 @@ func exportPreimages(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, false, false)
 	start := time.Now()
 
 	if err := utils.ExportPreimages(db, ctx.Args().First()); err != nil {
@@ -491,7 +491,7 @@ func dump(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, false, false)
 	for _, arg := range ctx.Args() {
 		var header *types.Header
 		if hashish(arg) {

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -62,6 +62,7 @@ Remove blockchain and state databases`,
 			dbPutCmd,
 			dbGetSlotsCmd,
 			dbDumpFreezerIndex,
+			blockPruneInspectCmd,
 		},
 	}
 	dbInspectCmd = cli.Command{
@@ -195,6 +196,16 @@ WARNING: This is a low-level operation which may cause database corruption!`,
 		},
 		Description: "This command displays information about the freezer index.",
 	}
+	blockPruneInspectCmd = cli.Command{
+		Action: utils.MigrateFlags(blockPruneInspect),
+		Name:   "inspect-reserved-oldest-blocks",
+		Flags: []cli.Flag{
+			utils.DataDirFlag,
+		},
+		Usage: "Inspect the ancientStore information after block-prune",
+		Description: `This commands will read current offset from kvdb, which is the current offset and starting BlockNumber
+		of ancientStore, will also displays the reserved number of blocks in ancientStore `,
+	}
 )
 
 func removeDB(ctx *cli.Context) error {
@@ -282,10 +293,19 @@ func inspect(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, true)
+	db := utils.MakeChainDatabase(ctx, stack, true, false)
 	defer db.Close()
 
 	return rawdb.InspectDatabase(db, prefix, start)
+}
+
+func blockPruneInspect(ctx *cli.Context) error {
+	stack, _ := makeConfigNode(ctx)
+	defer stack.Close()
+
+	db := utils.MakeChainDatabase(ctx, stack, true, true)
+	defer db.Close()
+	return rawdb.InspectBlockPrune(db)
 }
 
 func showLeveldbStats(db ethdb.Stater) {

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -282,7 +282,7 @@ func inspect(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, true)
 	defer db.Close()
 
 	return rawdb.InspectDatabase(db, prefix, start)

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -282,7 +282,7 @@ func inspect(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true)
+	db := utils.MakeChainDatabase(ctx, stack, true, false)
 	defer db.Close()
 
 	return rawdb.InspectDatabase(db, prefix, start)
@@ -305,7 +305,7 @@ func dbStats(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true)
+	db := utils.MakeChainDatabase(ctx, stack, true, false)
 	defer db.Close()
 
 	showLeveldbStats(db)
@@ -316,7 +316,7 @@ func dbCompact(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, false)
+	db := utils.MakeChainDatabase(ctx, stack, false, false)
 	defer db.Close()
 
 	log.Info("Stats before compaction")
@@ -340,7 +340,7 @@ func dbGet(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true)
+	db := utils.MakeChainDatabase(ctx, stack, true, false)
 	defer db.Close()
 
 	key, err := hexutil.Decode(ctx.Args().Get(0))
@@ -365,7 +365,7 @@ func dbDelete(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, false)
+	db := utils.MakeChainDatabase(ctx, stack, false, false)
 	defer db.Close()
 
 	key, err := hexutil.Decode(ctx.Args().Get(0))
@@ -392,7 +392,7 @@ func dbPut(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, false)
+	db := utils.MakeChainDatabase(ctx, stack, false, false)
 	defer db.Close()
 
 	var (
@@ -426,7 +426,7 @@ func dbDumpTrie(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true)
+	db := utils.MakeChainDatabase(ctx, stack, true, false)
 	defer db.Close()
 	var (
 		root  []byte

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -204,7 +204,7 @@ WARNING: This is a low-level operation which may cause database corruption!`,
 		},
 		Usage: "Inspect the ancientStore information",
 		Description: `This commands will read current offset from kvdb, which is the current offset and starting BlockNumber
-		of ancientStore, will also displays the reserved number of blocks in ancientStore `,
+of ancientStore, will also displays the reserved number of blocks in ancientStore `,
 	}
 )
 

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -293,7 +293,7 @@ func inspect(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, false, false)
 	defer db.Close()
 
 	return rawdb.InspectDatabase(db, prefix, start)
@@ -303,7 +303,7 @@ func ancientInspect(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, true)
+	db := utils.MakeChainDatabase(ctx, stack, true, true, false)
 	defer db.Close()
 	return rawdb.AncientInspect(db)
 }
@@ -325,7 +325,7 @@ func dbStats(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, false, false)
 	defer db.Close()
 
 	showLeveldbStats(db)
@@ -336,7 +336,7 @@ func dbCompact(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, false, false)
+	db := utils.MakeChainDatabase(ctx, stack, false, false, false)
 	defer db.Close()
 
 	log.Info("Stats before compaction")
@@ -360,7 +360,7 @@ func dbGet(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, false, false)
 	defer db.Close()
 
 	key, err := hexutil.Decode(ctx.Args().Get(0))
@@ -385,7 +385,7 @@ func dbDelete(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, false, false)
+	db := utils.MakeChainDatabase(ctx, stack, false, false, false)
 	defer db.Close()
 
 	key, err := hexutil.Decode(ctx.Args().Get(0))
@@ -412,7 +412,7 @@ func dbPut(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, false, false)
+	db := utils.MakeChainDatabase(ctx, stack, false, false, false)
 	defer db.Close()
 
 	var (
@@ -446,7 +446,7 @@ func dbDumpTrie(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, false, false)
 	defer db.Close()
 	var (
 		root  []byte

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -293,7 +293,7 @@ func inspect(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, false)
 	defer db.Close()
 
 	return rawdb.InspectDatabase(db, prefix, start)
@@ -303,7 +303,7 @@ func ancientInspect(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, true, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, true)
 	defer db.Close()
 	return rawdb.AncientInspect(db)
 }
@@ -325,7 +325,7 @@ func dbStats(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, false)
 	defer db.Close()
 
 	showLeveldbStats(db)
@@ -336,7 +336,7 @@ func dbCompact(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, false, false, false)
+	db := utils.MakeChainDatabase(ctx, stack, false, false)
 	defer db.Close()
 
 	log.Info("Stats before compaction")
@@ -360,7 +360,7 @@ func dbGet(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, false)
 	defer db.Close()
 
 	key, err := hexutil.Decode(ctx.Args().Get(0))
@@ -385,7 +385,7 @@ func dbDelete(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, false, false, false)
+	db := utils.MakeChainDatabase(ctx, stack, false, false)
 	defer db.Close()
 
 	key, err := hexutil.Decode(ctx.Args().Get(0))
@@ -412,7 +412,7 @@ func dbPut(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, false, false, false)
+	db := utils.MakeChainDatabase(ctx, stack, false, false)
 	defer db.Close()
 
 	var (
@@ -446,7 +446,7 @@ func dbDumpTrie(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, false)
 	defer db.Close()
 	var (
 		root  []byte

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -62,7 +62,7 @@ Remove blockchain and state databases`,
 			dbPutCmd,
 			dbGetSlotsCmd,
 			dbDumpFreezerIndex,
-			blockPruneInspectCmd,
+			ancientInspectCmd,
 		},
 	}
 	dbInspectCmd = cli.Command{
@@ -196,13 +196,13 @@ WARNING: This is a low-level operation which may cause database corruption!`,
 		},
 		Description: "This command displays information about the freezer index.",
 	}
-	blockPruneInspectCmd = cli.Command{
-		Action: utils.MigrateFlags(blockPruneInspect),
+	ancientInspectCmd = cli.Command{
+		Action: utils.MigrateFlags(ancientInspect),
 		Name:   "inspect-reserved-oldest-blocks",
 		Flags: []cli.Flag{
 			utils.DataDirFlag,
 		},
-		Usage: "Inspect the ancientStore information after block-prune",
+		Usage: "Inspect the ancientStore information",
 		Description: `This commands will read current offset from kvdb, which is the current offset and starting BlockNumber
 		of ancientStore, will also displays the reserved number of blocks in ancientStore `,
 	}
@@ -299,13 +299,13 @@ func inspect(ctx *cli.Context) error {
 	return rawdb.InspectDatabase(db, prefix, start)
 }
 
-func blockPruneInspect(ctx *cli.Context) error {
+func ancientInspect(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
 	db := utils.MakeChainDatabase(ctx, stack, true, true)
 	defer db.Close()
-	return rawdb.InspectBlockPrune(db)
+	return rawdb.AncientInspect(db)
 }
 
 func showLeveldbStats(db ethdb.Stater) {

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -165,7 +165,7 @@ var (
 		utils.MinerNotifyFullFlag,
 		configFileFlag,
 		utils.CatalystFlag,
-		utils.BlockPruneAmountLeft,
+		utils.BlockAmountReserved,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -165,6 +165,7 @@ var (
 		utils.MinerNotifyFullFlag,
 		configFileFlag,
 		utils.CatalystFlag,
+		utils.BlockPruneQuantity,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -165,8 +165,6 @@ var (
 		utils.MinerNotifyFullFlag,
 		configFileFlag,
 		utils.CatalystFlag,
-		utils.AncientBackUpFlag,
-		utils.GenesisFlag,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -165,7 +165,7 @@ var (
 		utils.MinerNotifyFullFlag,
 		configFileFlag,
 		utils.CatalystFlag,
-		utils.BlockPruneQuantity,
+		utils.BlockPruneAmountLeft,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -165,6 +165,8 @@ var (
 		utils.MinerNotifyFullFlag,
 		configFileFlag,
 		utils.CatalystFlag,
+		utils.AncientBackUpFlag,
+		utils.GenesisFlag,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -166,6 +166,7 @@ var (
 		configFileFlag,
 		utils.CatalystFlag,
 		utils.BlockAmountReserved,
+		utils.CheckSnapshotWithMPT,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/geth/pruneblock_test.go
+++ b/cmd/geth/pruneblock_test.go
@@ -86,7 +86,7 @@ func TestOfflineBlockPrune(t *testing.T) {
 		t.Fatalf("Failed to back up block: %v", err)
 	}
 
-	dbBack, err := rawdb.NewLevelDBDatabaseWithFreezer(chaindbPath, 0, 0, newAncientPath, "", false)
+	dbBack, err := rawdb.NewLevelDBDatabaseWithFreezer(chaindbPath, 0, 0, newAncientPath, "", false, true)
 	if err != nil {
 		t.Fatalf("failed to create database with ancient backend")
 	}
@@ -129,7 +129,7 @@ func TestOfflineBlockPrune(t *testing.T) {
 
 func BlockchainCreator(t *testing.T, chaindbPath, AncientPath string) (ethdb.Database, []*types.Block, []*types.Block, []types.Receipts, []*big.Int, uint64, *core.BlockChain) {
 	//create a database with ancient freezer
-	db, err := rawdb.NewLevelDBDatabaseWithFreezer(chaindbPath, 0, 0, AncientPath, "", false)
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(chaindbPath, 0, 0, AncientPath, "", false, true)
 	if err != nil {
 		t.Fatalf("failed to create database with ancient backend")
 	}

--- a/cmd/geth/pruneblock_test.go
+++ b/cmd/geth/pruneblock_test.go
@@ -78,13 +78,13 @@ func testBlockPruneForOffSetZero(t *testing.T, full bool, db ethdb.Database, bac
 	}
 	defer blockchain.Stop()
 
-	testBlockPruner, err := pruner.NewBlockPruner(db, n, oldfreezer)
+	testBlockPruner, err := pruner.NewBlockPruner(db, n, oldfreezer, backFreezer)
 	if err != nil {
 		t.Fatalf("failed to make new blockpruner: %v", err)
 	}
 
 	db.Close()
-	if err := testBlockPruner.BlockPruneBackUp(chaindbPath, 512, utils.MakeDatabaseHandles(), backFreezer, oldfreezer, "", false); err != nil {
+	if err := testBlockPruner.BlockPruneBackUp(chaindbPath, 512, utils.MakeDatabaseHandles(), "", false); err != nil {
 		log.Error("Failed to back up block", "err", err)
 		return err
 	}

--- a/cmd/geth/pruneblock_test.go
+++ b/cmd/geth/pruneblock_test.go
@@ -1,0 +1,151 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"io/ioutil"
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/cmd/utils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state/pruner"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// So we can deterministically seed different blockchains
+var (
+	canonicalSeed = 1
+
+	testKey, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	// testAddr is the Ethereum address of the tester account.
+	testAddr = crypto.PubkeyToAddress(testKey.PublicKey)
+)
+
+func TestOfflineBlockPrune(t *testing.T) {
+	datadir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Failed to create temporary datadir: %v", err)
+	}
+	os.RemoveAll(datadir)
+
+	chaindbPath := datadir + "/chaindata"
+	oldAncientPath := chaindbPath + "/ancient"
+	newAncientPath := chaindbPath + "/ancient_back"
+	//create a database with ancient freezer
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(chaindbPath, 512, utils.MakeDatabaseHandles(), oldAncientPath, "", false)
+
+	if err != nil {
+		t.Fatalf("failed to create database with ancient backend")
+	}
+
+	testBlockPruneForOffSetZero(t, true, db, newAncientPath, oldAncientPath, chaindbPath)
+
+}
+
+func testBlockPruneForOffSetZero(t *testing.T, full bool, db ethdb.Database, backFreezer, oldfreezer, chaindbPath string) error {
+	// Make chain starting from genesis
+	blockchain, n, err := newCanonical(t, db, ethash.NewFaker(), 92000, full, chaindbPath)
+	if err != nil {
+		t.Fatalf("failed to make new canonical chain: %v", err)
+	}
+	defer blockchain.Stop()
+
+	testBlockPruner, err := pruner.NewBlockPruner(db, n, oldfreezer)
+	if err != nil {
+		t.Fatalf("failed to make new blockpruner: %v", err)
+	}
+
+	db.Close()
+	if err := testBlockPruner.BlockPruneBackUp(chaindbPath, 512, utils.MakeDatabaseHandles(), backFreezer, oldfreezer, "", false); err != nil {
+		log.Error("Failed to back up block", "err", err)
+		return err
+	}
+
+	return nil
+
+}
+
+// newCanonical creates a chain database, and injects a deterministic canonical
+// chain. Depending on the full flag, if creates either a full block chain or a
+// header only chain.
+func newCanonical(t *testing.T, db ethdb.Database, engine consensus.Engine, height int, full bool, chaindbPath string) (*core.BlockChain, *node.Node, error) {
+
+	var (
+		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address = crypto.PubkeyToAddress(key.PublicKey)
+		funds   = big.NewInt(1000000000)
+		gspec   = &core.Genesis{Config: params.TestChainConfig, Alloc: core.GenesisAlloc{address: {Balance: funds}}}
+		genesis = gspec.MustCommit(db)
+	)
+
+	// Initialize a fresh chain with only a genesis block
+	blockchain, _ := core.NewBlockChain(db, nil, params.AllEthashProtocolChanges, engine, vm.Config{}, nil, nil)
+
+	// Full block-chain requested, same to GenerateChain func
+	blocks := makeBlockChain(genesis, height, engine, db, canonicalSeed)
+	_, err := blockchain.InsertChain(blocks)
+	nd, _ := startEthService(t, gspec, blocks, chaindbPath)
+	return blockchain, nd, err
+}
+
+// makeBlockChain creates a deterministic chain of blocks rooted at parent.
+func makeBlockChain(parent *types.Block, n int, engine consensus.Engine, db ethdb.Database, seed int) []*types.Block {
+	blocks, _ := core.GenerateChain(params.TestChainConfig, parent, engine, db, n, func(i int, b *core.BlockGen) {
+		b.SetCoinbase(common.Address{0: byte(seed), 19: byte(i)})
+	})
+	return blocks
+}
+
+// startEthService creates a full node instance for testing.
+func startEthService(t *testing.T, genesis *core.Genesis, blocks []*types.Block, chaindbPath string) (*node.Node, *eth.Ethereum) {
+	t.Helper()
+
+	n, err := node.New(&node.Config{DataDir: chaindbPath})
+	if err != nil {
+		t.Fatal("can't create node:", err)
+	}
+
+	ethcfg := &ethconfig.Config{Genesis: genesis, Ethash: ethash.Config{PowMode: ethash.ModeFake}}
+	ethservice, err := eth.New(n, ethcfg)
+	if err != nil {
+		t.Fatal("can't create eth service:", err)
+	}
+	if err := n.Start(); err != nil {
+		t.Fatal("can't start node:", err)
+	}
+	if _, err := ethservice.BlockChain().InsertChain(blocks); err != nil {
+		n.Close()
+		t.Fatal("can't import test blocks:", err)
+	}
+	ethservice.SetEtherbase(testAddr)
+
+	return n, ethservice
+}

--- a/cmd/geth/pruneblock_test.go
+++ b/cmd/geth/pruneblock_test.go
@@ -104,7 +104,11 @@ func testOfflineBlockPruneWithAmountReserved(t *testing.T, amountReserved uint64
 	for blockNumber := startBlockNumber; blockNumber < startBlockNumber+amountReserved; blockNumber++ {
 		blockHash := rawdb.ReadCanonicalHash(dbBack, blockNumber)
 		block := rawdb.ReadBlock(dbBack, blockHash, blockNumber)
-		if reflect.DeepEqual(block, blockList[blockNumber-startBlockNumber]) {
+
+		if block.Hash() != blockHash {
+			t.Fatalf("block data did not match between oldDb and backupDb")
+		}
+		if blockList[blockNumber-startBlockNumber].Hash() != blockHash {
 			t.Fatalf("block data did not match between oldDb and backupDb")
 		}
 
@@ -117,8 +121,7 @@ func testOfflineBlockPruneWithAmountReserved(t *testing.T, amountReserved uint64
 		if td == nil {
 			t.Fatalf("Failed to ReadTd: %v", consensus.ErrUnknownAncestor)
 		}
-		externTd := new(big.Int).Add(block.Difficulty(), td)
-		if reflect.DeepEqual(externTd, externTdList[blockNumber-startBlockNumber]) {
+		if !reflect.DeepEqual(td, externTdList[blockNumber-startBlockNumber]) {
 			t.Fatalf("externTd did not match between oldDb and backupDb")
 		}
 	}
@@ -198,8 +201,7 @@ func BlockchainCreator(t *testing.T, chaindbPath, AncientPath string, blockRemai
 		if td == nil {
 			t.Fatalf("Failed to ReadTd: %v", consensus.ErrUnknownAncestor)
 		}
-		externTd := new(big.Int).Add(block.Difficulty(), td)
-		externTdList = append(externTdList, externTd)
+		externTdList = append(externTdList, td)
 	}
 
 	return db, blocks, blockList, receiptsList, externTdList, startBlockNumber, blockchain

--- a/cmd/geth/pruneblock_test.go
+++ b/cmd/geth/pruneblock_test.go
@@ -24,7 +24,6 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 	"time"
 
@@ -121,7 +120,7 @@ func testOfflineBlockPruneWithAmountReserved(t *testing.T, amountReserved uint64
 		if td == nil {
 			t.Fatalf("Failed to ReadTd: %v", consensus.ErrUnknownAncestor)
 		}
-		if !reflect.DeepEqual(td, externTdList[blockNumber-startBlockNumber]) {
+		if td.Cmp(externTdList[blockNumber-startBlockNumber]) != 0 {
 			t.Fatalf("externTd did not match between oldDb and backupDb")
 		}
 	}

--- a/cmd/geth/pruneblock_test.go
+++ b/cmd/geth/pruneblock_test.go
@@ -94,7 +94,7 @@ func testOfflineBlockPruneWithAmountReserved(t *testing.T, amountReserved uint64
 		t.Fatalf("Failed to back up block: %v", err)
 	}
 
-	dbBack, err := rawdb.NewLevelDBDatabaseWithFreezer(chaindbPath, 0, 0, newAncientPath, "", false, true)
+	dbBack, err := rawdb.NewLevelDBDatabaseWithFreezer(chaindbPath, 0, 0, newAncientPath, "", false, true, false)
 	if err != nil {
 		t.Fatalf("failed to create database with ancient backend")
 	}
@@ -137,7 +137,7 @@ func testOfflineBlockPruneWithAmountReserved(t *testing.T, amountReserved uint64
 
 func BlockchainCreator(t *testing.T, chaindbPath, AncientPath string, blockRemain uint64) (ethdb.Database, []*types.Block, []*types.Block, []types.Receipts, []*big.Int, uint64, *core.BlockChain) {
 	//create a database with ancient freezer
-	db, err := rawdb.NewLevelDBDatabaseWithFreezer(chaindbPath, 0, 0, AncientPath, "", false, false)
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(chaindbPath, 0, 0, AncientPath, "", false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create database with ancient backend")
 	}

--- a/cmd/geth/pruneblock_test.go
+++ b/cmd/geth/pruneblock_test.go
@@ -90,7 +90,7 @@ func testOfflineBlockPruneWithAmountReserved(t *testing.T, amountReserved uint64
 	if err != nil {
 		t.Fatalf("failed to make new blockpruner: %v", err)
 	}
-	if err := testBlockPruner.BlockPruneBackUp(chaindbPath, 512, utils.MakeDatabaseHandles(), "", false); err != nil {
+	if err := testBlockPruner.BlockPruneBackUp(chaindbPath, 512, utils.MakeDatabaseHandles(), "", false, false); err != nil {
 		t.Fatalf("Failed to back up block: %v", err)
 	}
 
@@ -179,7 +179,7 @@ func BlockchainCreator(t *testing.T, chaindbPath, AncientPath string, blockRemai
 		t.Fatalf("block amount is not enough for pruning: %v", err)
 	}
 
-	oldOffSet := rawdb.ReadOffSetOfAncientFreezer(db)
+	oldOffSet := rawdb.ReadOffSetOfCurrentAncientFreezer(db)
 	// Get the actual start block number.
 	startBlockNumber := frozen - blockRemain + oldOffSet
 	// Initialize the slice to buffer the block data left.

--- a/cmd/geth/pruneblock_test.go
+++ b/cmd/geth/pruneblock_test.go
@@ -65,12 +65,12 @@ var (
 
 func TestOfflineBlockPrune(t *testing.T) {
 	//Corner case for 0 remain in ancinetStore.
-	testOfflineBlockPruneWithAmountLeft(t, 0)
+	testOfflineBlockPruneWithAmountReserved(t, 0)
 	//General case.
-	testOfflineBlockPruneWithAmountLeft(t, 100)
+	testOfflineBlockPruneWithAmountReserved(t, 100)
 }
 
-func testOfflineBlockPruneWithAmountLeft(t *testing.T, amountLeft uint64) {
+func testOfflineBlockPruneWithAmountReserved(t *testing.T, amountReserved uint64) {
 	datadir, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatalf("Failed to create temporary datadir: %v", err)
@@ -81,12 +81,12 @@ func testOfflineBlockPruneWithAmountLeft(t *testing.T, amountLeft uint64) {
 	oldAncientPath := filepath.Join(chaindbPath, "ancient")
 	newAncientPath := filepath.Join(chaindbPath, "ancient_back")
 
-	db, blocks, blockList, receiptsList, externTdList, startBlockNumber, _ := BlockchainCreator(t, chaindbPath, oldAncientPath, amountLeft)
+	db, blocks, blockList, receiptsList, externTdList, startBlockNumber, _ := BlockchainCreator(t, chaindbPath, oldAncientPath, amountReserved)
 	node, _ := startEthService(t, gspec, blocks, chaindbPath)
 	defer node.Close()
 
-	//Initialize a block pruner for pruning, only remain amountLeft blocks backward.
-	testBlockPruner, err := pruner.NewBlockPruner(db, node, oldAncientPath, newAncientPath, amountLeft)
+	//Initialize a block pruner for pruning, only remain amountReserved blocks backward.
+	testBlockPruner, err := pruner.NewBlockPruner(db, node, oldAncientPath, newAncientPath, amountReserved)
 	if err != nil {
 		t.Fatalf("failed to make new blockpruner: %v", err)
 	}
@@ -101,7 +101,7 @@ func testOfflineBlockPruneWithAmountLeft(t *testing.T, amountLeft uint64) {
 	defer dbBack.Close()
 
 	//check against if the backup data matched original one
-	for blockNumber := startBlockNumber; blockNumber < startBlockNumber+amountLeft; blockNumber++ {
+	for blockNumber := startBlockNumber; blockNumber < startBlockNumber+amountReserved; blockNumber++ {
 		blockHash := rawdb.ReadCanonicalHash(dbBack, blockNumber)
 		block := rawdb.ReadBlock(dbBack, blockHash, blockNumber)
 		if reflect.DeepEqual(block, blockList[blockNumber-startBlockNumber]) {

--- a/cmd/geth/pruneblock_test.go
+++ b/cmd/geth/pruneblock_test.go
@@ -86,7 +86,7 @@ func testOfflineBlockPruneWithAmountReserved(t *testing.T, amountReserved uint64
 	defer node.Close()
 
 	//Initialize a block pruner for pruning, only remain amountReserved blocks backward.
-	testBlockPruner, err := pruner.NewBlockPruner(db, node, oldAncientPath, newAncientPath, amountReserved)
+	testBlockPruner := pruner.NewBlockPruner(db, node, oldAncientPath, newAncientPath, amountReserved)
 	if err != nil {
 		t.Fatalf("failed to make new blockpruner: %v", err)
 	}

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -93,6 +93,7 @@ the trie clean cache with default directory will be deleted.
 				Flags: []cli.Flag{
 					utils.DataDirFlag,
 					utils.AncientFlag,
+					utils.BlockPruneQuantity,
 				},
 				Description: `
 geth offline prune-block for block data in ancientdb.
@@ -271,6 +272,7 @@ func accessDb(ctx *cli.Context, stack *node.Node) (ethdb.Database, error) {
 func pruneBlock(ctx *cli.Context) error {
 	stack, config := makeConfigNode(ctx)
 	defer stack.Close()
+	BlockPruneQuantity := ctx.GlobalUint64(utils.BlockPruneQuantity.Name)
 	chaindb, err := accessDb(ctx, stack)
 	if err != nil {
 		return err
@@ -293,7 +295,7 @@ func pruneBlock(ctx *cli.Context) error {
 		return err
 	}
 
-	blockpruner, err := pruner.NewBlockPruner(chaindb, stack, oldAncientPath, newAncientPath)
+	blockpruner, err := pruner.NewBlockPruner(chaindb, stack, oldAncientPath, newAncientPath, BlockPruneQuantity)
 	if err != nil {
 		return err
 	}

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -97,7 +97,7 @@ the trie clean cache with default directory will be deleted.
 				},
 				Description: `
 geth offline prune-block for block data in ancientdb.
-The amount of blocks expected for remaining after prune can be specified via blockprune-amount in this command,
+The amount of blocks expected for remaining after prune can be specified via reserved-recent-blocks in this command,
 will prune and only remain the specified amount of old block data in ancientdb.
 the brief workflow is to backup the the number of this specified amount blocks backward in original ancientdb 
 into new ancient_backup, then delete the original ancientdb dir and rename the ancient_backup to original one for replacement,

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -320,7 +320,7 @@ func pruneState(ctx *cli.Context) error {
 	stack, config := makeConfigNode(ctx)
 	defer stack.Close()
 
-	chaindb := utils.MakeChainDatabase(ctx, stack, false)
+	chaindb := utils.MakeChainDatabase(ctx, stack, false, false)
 	pruner, err := pruner.NewPruner(chaindb, stack.ResolvePath(""), stack.ResolvePath(config.Eth.TrieCleanCacheJournal), ctx.GlobalUint64(utils.BloomFilterSizeFlag.Name), ctx.GlobalUint64(utils.TriesInMemoryFlag.Name))
 	if err != nil {
 		log.Error("Failed to open snapshot tree", "err", err)
@@ -349,7 +349,7 @@ func verifyState(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	chaindb := utils.MakeChainDatabase(ctx, stack, true)
+	chaindb := utils.MakeChainDatabase(ctx, stack, true, false)
 	headBlock := rawdb.ReadHeadBlock(chaindb)
 	if headBlock == nil {
 		log.Error("Failed to load head block")
@@ -387,7 +387,7 @@ func traverseState(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	chaindb := utils.MakeChainDatabase(ctx, stack, true)
+	chaindb := utils.MakeChainDatabase(ctx, stack, true, false)
 	headBlock := rawdb.ReadHeadBlock(chaindb)
 	if headBlock == nil {
 		log.Error("Failed to load head block")
@@ -477,7 +477,7 @@ func traverseRawState(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	chaindb := utils.MakeChainDatabase(ctx, stack, true)
+	chaindb := utils.MakeChainDatabase(ctx, stack, true, false)
 	headBlock := rawdb.ReadHeadBlock(chaindb)
 	if headBlock == nil {
 		log.Error("Failed to load head block")

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -18,15 +18,12 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
-	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/state/pruner"
@@ -93,8 +90,6 @@ the trie clean cache with default directory will be deleted.
 				Flags: []cli.Flag{
 					utils.DataDirFlag,
 					utils.AncientFlag,
-					utils.AncientBackUpFlag,
-					utils.GenesisFlag,
 				},
 				Description: `
 Offline prune for block data.
@@ -171,54 +166,60 @@ It's also usable without snapshot enabled.
 
 func pruneBlock(ctx *cli.Context) error {
 	stack, config := makeConfigNode(ctx)
-	//defer stack.Close()
-	chaindb := utils.MakeChainDatabase(ctx, stack, false)
-	// Make sure we have a valid genesis JSON
-	genesisPath := ctx.GlobalString(utils.GenesisFlag.Name)
-	if len(genesisPath) == 0 {
-		utils.Fatalf("Must supply path to genesis JSON file")
-	}
-	file, err := os.Open(genesisPath)
-	if err != nil {
-		utils.Fatalf("Failed to read genesis file: %v", err)
-	}
-	defer file.Close()
+	defer stack.Close()
 
-	genesis := new(core.Genesis)
-	if err := json.NewDecoder(file).Decode(genesis); err != nil {
-		utils.Fatalf("invalid genesis file: %v", err)
-	}
-	if err != nil {
-		utils.Fatalf("Failed to decode genesis: %v", err)
-	}
-	freezer := config.Eth.DatabaseFreezer
+	chaindb := utils.MakeChainDatabaseForBlockPrune(ctx, stack, false)
+	chaindb.Close()
 
+	var oldAncientPath, newAncientPath string
+	if path := getAncientPath(ctx); path != "" {
+		oldAncientPath = path + "/ancient"
+		newAncientPath = path + "/ancient_back"
+	} else {
+		utils.Fatalf("Prune failed, did not specify the AncientPath %v")
+	}
+
+	//lock, _, err := fileutil.Flock(filepath.Join(oldAncientPath, "FLOCK"))
+	// lock, _, err := fileutil.Flock(oldAncientPath)
+	// if err != nil {
+	// 	return err
+	// }
+	// _, err = os.Open(oldAncientPath)
+	// if err != nil {
+	// 	utils.Fatalf("Failed to read genesis file: %v", err)
+	// }
 	for _, name := range []string{"chaindata"} {
-		root := stack.ResolvePath(name) // /Users/user/storage/Private_BSC_Storage/build/bin/node/geth/chaindata
+		root := stack.ResolvePath(name)
 		switch {
-		case freezer == "":
-			freezer = filepath.Join(root, "ancient")
-		case !filepath.IsAbs(freezer):
-			freezer = stack.ResolvePath(freezer)
+		case oldAncientPath == "":
+			oldAncientPath = filepath.Join(root, "ancient")
+		case !filepath.IsAbs(oldAncientPath):
+			oldAncientPath = stack.ResolvePath(oldAncientPath)
 		}
-		pruner, err := pruner.NewBlockPruner(chaindb, stack, stack.ResolvePath(""), freezer, genesis)
+		pruner, err := pruner.NewBlockPruner(chaindb, stack, stack.ResolvePath(""), oldAncientPath)
 		if err != nil {
 			utils.Fatalf("Failed to create block pruner", err)
 		}
-		backfreezer := filepath.Join(root, "ancient_back_up")
-		if err := pruner.BlockPruneBackUp(name, config.Eth.DatabaseCache, utils.MakeDatabaseHandles(), backfreezer, "", false); err != nil {
+
+		if err := pruner.BlockPruneBackUp(name, config.Eth.DatabaseCache, utils.MakeDatabaseHandles(), newAncientPath, oldAncientPath, "", false); err != nil {
 			log.Error("Failed to back up block", "err", err)
 			return err
 		}
 	}
+
 	log.Info("geth block offline pruning backup successfully")
-	oldAncientPath := ctx.GlobalString(utils.AncientFlag.Name)
-	newAncientPath := ctx.GlobalString(utils.AncientBackUpFlag.Name)
+
 	if err := pruner.BlockPrune(oldAncientPath, newAncientPath); err != nil {
 		utils.Fatalf("Failed to prune block", err)
 		return err
 	}
+	//lock.Release()
+	log.Info("Block prune successfully")
 	return nil
+}
+
+func getAncientPath(ctx *cli.Context) string {
+	return ctx.GlobalString(utils.AncientFlag.Name)
 }
 
 func pruneState(ctx *cli.Context) error {

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -24,6 +24,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/prometheus/tsdb/fileutil"
+	cli "gopkg.in/urfave/cli.v1"
+
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -36,8 +39,6 @@ import (
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
-	"github.com/prometheus/tsdb/fileutil"
-	cli "gopkg.in/urfave/cli.v1"
 )
 
 var (

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -182,7 +182,7 @@ It's also usable without snapshot enabled.
 func accessDb(ctx *cli.Context, stack *node.Node) (ethdb.Database, error) {
 	//The layer of tries trees that keep in memory.
 	TriesInMemory := int(ctx.GlobalUint64(utils.TriesInMemoryFlag.Name))
-	chaindb := utils.MakeChainDatabase(ctx, stack, false, true)
+	chaindb := utils.MakeChainDatabase(ctx, stack, false, true, false)
 	defer chaindb.Close()
 
 	headBlock := rawdb.ReadHeadBlock(chaindb)
@@ -295,7 +295,7 @@ func pruneBlock(ctx *cli.Context) error {
 		return err
 	}
 	if exist {
-		log.Warn("file lock existed, waiting for prune recovery and continue", "err", err)
+		log.Info("file lock existed, waiting for prune recovery and continue", "err", err)
 		if err := blockpruner.RecoverInterruption("chaindata", config.Eth.DatabaseCache, utils.MakeDatabaseHandles(), "", false); err != nil {
 			log.Error("Pruning failed", "err", err)
 			return err
@@ -337,7 +337,7 @@ func pruneState(ctx *cli.Context) error {
 	stack, config := makeConfigNode(ctx)
 	defer stack.Close()
 
-	chaindb := utils.MakeChainDatabase(ctx, stack, false, false)
+	chaindb := utils.MakeChainDatabase(ctx, stack, false, false, false)
 	pruner, err := pruner.NewPruner(chaindb, stack.ResolvePath(""), stack.ResolvePath(config.Eth.TrieCleanCacheJournal), ctx.GlobalUint64(utils.BloomFilterSizeFlag.Name), ctx.GlobalUint64(utils.TriesInMemoryFlag.Name))
 	if err != nil {
 		log.Error("Failed to open snapshot tree", "err", err)
@@ -366,7 +366,7 @@ func verifyState(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	chaindb := utils.MakeChainDatabase(ctx, stack, true, false)
+	chaindb := utils.MakeChainDatabase(ctx, stack, true, false, false)
 	headBlock := rawdb.ReadHeadBlock(chaindb)
 	if headBlock == nil {
 		log.Error("Failed to load head block")
@@ -404,7 +404,7 @@ func traverseState(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	chaindb := utils.MakeChainDatabase(ctx, stack, true, false)
+	chaindb := utils.MakeChainDatabase(ctx, stack, true, false, false)
 	headBlock := rawdb.ReadHeadBlock(chaindb)
 	if headBlock == nil {
 		log.Error("Failed to load head block")
@@ -494,7 +494,7 @@ func traverseRawState(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	chaindb := utils.MakeChainDatabase(ctx, stack, true, false)
+	chaindb := utils.MakeChainDatabase(ctx, stack, true, false, false)
 	headBlock := rawdb.ReadHeadBlock(chaindb)
 	if headBlock == nil {
 		log.Error("Failed to load head block")

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -97,7 +97,7 @@ the trie clean cache with default directory will be deleted.
 				},
 				Description: `
 geth offline prune-block for block data in ancientdb.
-The amount of blocks expected for remaining after prune can be specified via reserved-recent-blocks in this command,
+The amount of blocks expected for remaining after prune can be specified via block-amount-reserved in this command,
 will prune and only remain the specified amount of old block data in ancientdb.
 the brief workflow is to backup the the number of this specified amount blocks backward in original ancientdb 
 into new ancient_backup, then delete the original ancientdb dir and rename the ancient_backup to original one for replacement,

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -183,7 +183,7 @@ It's also usable without snapshot enabled.
 func accessDb(ctx *cli.Context, stack *node.Node) (ethdb.Database, error) {
 	//The layer of tries trees that keep in memory.
 	TriesInMemory := int(ctx.GlobalUint64(utils.TriesInMemoryFlag.Name))
-	chaindb := utils.MakeChainDatabase(ctx, stack, false, true, false)
+	chaindb := utils.MakeChainDatabase(ctx, stack, false, true)
 	defer chaindb.Close()
 
 	if !ctx.GlobalBool(utils.CheckSnapshotWithMPT.Name) {
@@ -341,7 +341,7 @@ func pruneState(ctx *cli.Context) error {
 	stack, config := makeConfigNode(ctx)
 	defer stack.Close()
 
-	chaindb := utils.MakeChainDatabase(ctx, stack, false, false, false)
+	chaindb := utils.MakeChainDatabase(ctx, stack, false, false)
 	pruner, err := pruner.NewPruner(chaindb, stack.ResolvePath(""), stack.ResolvePath(config.Eth.TrieCleanCacheJournal), ctx.GlobalUint64(utils.BloomFilterSizeFlag.Name), ctx.GlobalUint64(utils.TriesInMemoryFlag.Name))
 	if err != nil {
 		log.Error("Failed to open snapshot tree", "err", err)
@@ -370,7 +370,7 @@ func verifyState(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	chaindb := utils.MakeChainDatabase(ctx, stack, true, false, false)
+	chaindb := utils.MakeChainDatabase(ctx, stack, true, false)
 	headBlock := rawdb.ReadHeadBlock(chaindb)
 	if headBlock == nil {
 		log.Error("Failed to load head block")
@@ -408,7 +408,7 @@ func traverseState(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	chaindb := utils.MakeChainDatabase(ctx, stack, true, false, false)
+	chaindb := utils.MakeChainDatabase(ctx, stack, true, false)
 	headBlock := rawdb.ReadHeadBlock(chaindb)
 	if headBlock == nil {
 		log.Error("Failed to load head block")
@@ -498,7 +498,7 @@ func traverseRawState(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	chaindb := utils.MakeChainDatabase(ctx, stack, true, false, false)
+	chaindb := utils.MakeChainDatabase(ctx, stack, true, false)
 	headBlock := rawdb.ReadHeadBlock(chaindb)
 	if headBlock == nil {
 		log.Error("Failed to load head block")

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -97,6 +97,7 @@ the trie clean cache with default directory will be deleted.
 					utils.AncientFlag,
 					utils.BlockAmountReserved,
 					utils.TriesInMemoryFlag,
+					utils.CheckSnapshotWithMPT,
 				},
 				Description: `
 geth offline prune-block for block data in ancientdb.
@@ -185,6 +186,9 @@ func accessDb(ctx *cli.Context, stack *node.Node) (ethdb.Database, error) {
 	chaindb := utils.MakeChainDatabase(ctx, stack, false, true, false)
 	defer chaindb.Close()
 
+	if !ctx.GlobalBool(utils.CheckSnapshotWithMPT.Name) {
+		return chaindb, nil
+	}
 	headBlock := rawdb.ReadHeadBlock(chaindb)
 	if headBlock == nil {
 		return nil, errors.New("failed to load head block")

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -58,7 +58,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.LightKDFFlag,
 			utils.WhitelistFlag,
 			utils.TriesInMemoryFlag,
-			utils.BlockPruneQuantity,
+			utils.BlockPruneAmountLeft,
 		},
 	},
 	{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -58,6 +58,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.LightKDFFlag,
 			utils.WhitelistFlag,
 			utils.TriesInMemoryFlag,
+			utils.BlockPruneQuantity,
 		},
 	},
 	{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -59,6 +59,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.WhitelistFlag,
 			utils.TriesInMemoryFlag,
 			utils.BlockAmountReserved,
+			utils.CheckSnapshotWithMPT,
 		},
 	},
 	{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -58,7 +58,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.LightKDFFlag,
 			utils.WhitelistFlag,
 			utils.TriesInMemoryFlag,
-			utils.BlockPruneAmountLeft,
+			utils.BlockAmountReserved,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -134,6 +134,10 @@ var (
 		Name:  "datadir.ancient",
 		Usage: "Data directory for ancient chain segments (default = inside chaindata)",
 	}
+	AncientBackUpFlag = DirectoryFlag{
+		Name:  "datadir.ancient",
+		Usage: "Data directory for ancient directory backup (default = inside chaindata)",
+	}
 	DiffFlag = DirectoryFlag{
 		Name:  "datadir.diff",
 		Usage: "Data directory for difflayer segments (default = inside chaindata)",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -135,8 +135,12 @@ var (
 		Usage: "Data directory for ancient chain segments (default = inside chaindata)",
 	}
 	AncientBackUpFlag = DirectoryFlag{
-		Name:  "datadir.ancient",
-		Usage: "Data directory for ancient directory backup (default = inside chaindata)",
+		Name:  "datadir.backup",
+		Usage: "Data directory for ancient directory backup",
+	}
+	GenesisFlag = DirectoryFlag{
+		Name:  "datadir.genesis",
+		Usage: "Data directory for genesis file",
 	}
 	DiffFlag = DirectoryFlag{
 		Name:  "datadir.diff",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -829,7 +829,7 @@ var (
 	}
 
 	BlockPruneAmountLeft = cli.Uint64Flag{
-		Name:  "blockprune-amount",
+		Name:  "reserved-recent-blocks",
 		Usage: "Sets the expected remained amount of blocks for offline block prune",
 	}
 )

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -828,9 +828,9 @@ var (
 		Usage: "Catalyst mode (eth2 integration testing)",
 	}
 
-	BlockPruneQuantity = cli.Uint64Flag{
-		Name:  "blockprune-quantity",
-		Usage: "Sets the quantity of blocks for offline block prune",
+	BlockPruneAmountLeft = cli.Uint64Flag{
+		Name:  "blockprune-amount",
+		Usage: "Sets the expected remained amount of blocks for offline block prune",
 	}
 )
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -827,6 +827,11 @@ var (
 		Name:  "catalyst",
 		Usage: "Catalyst mode (eth2 integration testing)",
 	}
+
+	BlockPruneQuantity = cli.Uint64Flag{
+		Name:  "blockprune-quantity",
+		Usage: "Sets the quantity of blocks for offline block prune",
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1883,7 +1883,7 @@ func SplitTagsFlag(tagsFlag string) map[string]string {
 }
 
 // MakeChainDatabase open an LevelDB using the flags passed to the client and will hard crash if it fails.
-func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.Database {
+func MakeChainDatabase(ctx *cli.Context, stack *node.Node, args ...bool) ethdb.Database {
 	var (
 		cache   = ctx.GlobalInt(CacheFlag.Name) * ctx.GlobalInt(CacheDatabaseFlag.Name) / 100
 		handles = MakeDatabaseHandles()
@@ -1893,32 +1893,10 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.
 	)
 	if ctx.GlobalString(SyncModeFlag.Name) == "light" {
 		name := "lightchaindata"
-		chainDb, err = stack.OpenDatabase(name, cache, handles, "", readonly)
+		chainDb, err = stack.OpenDatabase(name, cache, handles, "", args[0])
 	} else {
 		name := "chaindata"
-		chainDb, err = stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", readonly)
-	}
-	if err != nil {
-		Fatalf("Could not open database: %v", err)
-	}
-	return chainDb
-}
-
-// MakeChainDatabase open an LevelDB using the flags passed to the client and will hard crash if it fails.
-func MakeChainDatabaseForBlockPrune(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.Database {
-	var (
-		cache   = ctx.GlobalInt(CacheFlag.Name) * ctx.GlobalInt(CacheDatabaseFlag.Name) / 100
-		handles = MakeDatabaseHandles()
-
-		err     error
-		chainDb ethdb.Database
-	)
-	if ctx.GlobalString(SyncModeFlag.Name) == "light" {
-		name := "lightchaindata"
-		chainDb, err = stack.OpenDatabase(name, cache, handles, "", readonly)
-	} else {
-		name := "chaindata"
-		chainDb, err = stack.OpenDatabaseWithFreezerForPruneBlock(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", readonly)
+		chainDb, err = stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", args...)
 	}
 	if err != nil {
 		Fatalf("Could not open database: %v", err)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1883,7 +1883,7 @@ func SplitTagsFlag(tagsFlag string) map[string]string {
 }
 
 // MakeChainDatabase open an LevelDB using the flags passed to the client and will hard crash if it fails.
-func MakeChainDatabase(ctx *cli.Context, stack *node.Node, args ...bool) ethdb.Database {
+func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly ...bool) ethdb.Database {
 	var (
 		cache   = ctx.GlobalInt(CacheFlag.Name) * ctx.GlobalInt(CacheDatabaseFlag.Name) / 100
 		handles = MakeDatabaseHandles()
@@ -1893,10 +1893,10 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, args ...bool) ethdb.D
 	)
 	if ctx.GlobalString(SyncModeFlag.Name) == "light" {
 		name := "lightchaindata"
-		chainDb, err = stack.OpenDatabase(name, cache, handles, "", args[0])
+		chainDb, err = stack.OpenDatabase(name, cache, handles, "", readonly[0])
 	} else {
 		name := "chaindata"
-		chainDb, err = stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", args...)
+		chainDb, err = stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", readonly...)
 	}
 	if err != nil {
 		Fatalf("Could not open database: %v", err)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -33,6 +33,10 @@ import (
 	"text/template"
 	"time"
 
+	pcsclite "github.com/gballet/go-libpcsclite"
+	gopsutil "github.com/shirou/gopsutil/mem"
+	"gopkg.in/urfave/cli.v1"
+
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
@@ -66,9 +70,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/nat"
 	"github.com/ethereum/go-ethereum/p2p/netutil"
 	"github.com/ethereum/go-ethereum/params"
-	pcsclite "github.com/gballet/go-libpcsclite"
-	gopsutil "github.com/shirou/gopsutil/mem"
-	"gopkg.in/urfave/cli.v1"
 )
 
 func init() {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1775,7 +1775,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		if ctx.GlobalIsSet(DataDirFlag.Name) {
 			// Check if we have an already initialized chain and fall back to
 			// that if so. Otherwise we need to generate a new genesis spec.
-			chaindb := MakeChainDatabase(ctx, stack, false, false, false) // TODO (MariusVanDerWijden) make this read only
+			chaindb := MakeChainDatabase(ctx, stack, false, false) // TODO (MariusVanDerWijden) make this read only
 			if rawdb.ReadCanonicalHash(chaindb, 0) != (common.Hash{}) {
 				cfg.Genesis = nil // fallback to db content
 			}
@@ -1894,7 +1894,7 @@ func SplitTagsFlag(tagsFlag string) map[string]string {
 }
 
 // MakeChainDatabase open an LevelDB using the flags passed to the client and will hard crash if it fails.
-func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly, disableFreeze, isLastOffset bool) ethdb.Database {
+func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly, disableFreeze bool) ethdb.Database {
 	var (
 		cache   = ctx.GlobalInt(CacheFlag.Name) * ctx.GlobalInt(CacheDatabaseFlag.Name) / 100
 		handles = MakeDatabaseHandles()
@@ -1907,7 +1907,7 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly, disableFree
 		chainDb, err = stack.OpenDatabase(name, cache, handles, "", readonly)
 	} else {
 		name := "chaindata"
-		chainDb, err = stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", readonly, disableFreeze, isLastOffset)
+		chainDb, err = stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", readonly, disableFreeze, false)
 	}
 	if err != nil {
 		Fatalf("Could not open database: %v", err)
@@ -1937,7 +1937,7 @@ func MakeGenesis(ctx *cli.Context) *core.Genesis {
 // MakeChain creates a chain manager from set command line flags.
 func MakeChain(ctx *cli.Context, stack *node.Node) (chain *core.BlockChain, chainDb ethdb.Database) {
 	var err error
-	chainDb = MakeChainDatabase(ctx, stack, false, false, false) // TODO(rjl493456442) support read-only database
+	chainDb = MakeChainDatabase(ctx, stack, false, false) // TODO(rjl493456442) support read-only database
 	config, _, err := core.SetupGenesisBlock(chainDb, MakeGenesis(ctx))
 	if err != nil {
 		Fatalf("%v", err)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1770,7 +1770,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		if ctx.GlobalIsSet(DataDirFlag.Name) {
 			// Check if we have an already initialized chain and fall back to
 			// that if so. Otherwise we need to generate a new genesis spec.
-			chaindb := MakeChainDatabase(ctx, stack, false, false) // TODO (MariusVanDerWijden) make this read only
+			chaindb := MakeChainDatabase(ctx, stack, false, false, false) // TODO (MariusVanDerWijden) make this read only
 			if rawdb.ReadCanonicalHash(chaindb, 0) != (common.Hash{}) {
 				cfg.Genesis = nil // fallback to db content
 			}
@@ -1889,7 +1889,7 @@ func SplitTagsFlag(tagsFlag string) map[string]string {
 }
 
 // MakeChainDatabase open an LevelDB using the flags passed to the client and will hard crash if it fails.
-func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly, disableFreeze bool) ethdb.Database {
+func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly, disableFreeze, isLastOffset bool) ethdb.Database {
 	var (
 		cache   = ctx.GlobalInt(CacheFlag.Name) * ctx.GlobalInt(CacheDatabaseFlag.Name) / 100
 		handles = MakeDatabaseHandles()
@@ -1902,7 +1902,7 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly, disableFree
 		chainDb, err = stack.OpenDatabase(name, cache, handles, "", readonly)
 	} else {
 		name := "chaindata"
-		chainDb, err = stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", readonly, disableFreeze)
+		chainDb, err = stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", readonly, disableFreeze, isLastOffset)
 	}
 	if err != nil {
 		Fatalf("Could not open database: %v", err)
@@ -1932,7 +1932,7 @@ func MakeGenesis(ctx *cli.Context) *core.Genesis {
 // MakeChain creates a chain manager from set command line flags.
 func MakeChain(ctx *cli.Context, stack *node.Node) (chain *core.BlockChain, chainDb ethdb.Database) {
 	var err error
-	chainDb = MakeChainDatabase(ctx, stack, false, false) // TODO(rjl493456442) support read-only database
+	chainDb = MakeChainDatabase(ctx, stack, false, false, false) // TODO(rjl493456442) support read-only database
 	config, _, err := core.SetupGenesisBlock(chainDb, MakeGenesis(ctx))
 	if err != nil {
 		Fatalf("%v", err)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -833,6 +833,11 @@ var (
 		Name:  "block-amount-reserved",
 		Usage: "Sets the expected remained amount of blocks for offline block prune",
 	}
+
+	CheckSnapshotWithMPT = cli.BoolFlag{
+		Name:  "check-snapshot-with-mpt",
+		Usage: "Enable checking between snapshot and MPT ",
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1888,7 +1888,7 @@ func SplitTagsFlag(tagsFlag string) map[string]string {
 }
 
 // MakeChainDatabase open an LevelDB using the flags passed to the client and will hard crash if it fails.
-func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly, disablFreeze bool) ethdb.Database {
+func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly, disableFreeze bool) ethdb.Database {
 	var (
 		cache   = ctx.GlobalInt(CacheFlag.Name) * ctx.GlobalInt(CacheDatabaseFlag.Name) / 100
 		handles = MakeDatabaseHandles()
@@ -1901,7 +1901,7 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly, disablFreez
 		chainDb, err = stack.OpenDatabase(name, cache, handles, "", readonly)
 	} else {
 		name := "chaindata"
-		chainDb, err = stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", readonly, disablFreeze)
+		chainDb, err = stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", readonly, disableFreeze)
 	}
 	if err != nil {
 		Fatalf("Could not open database: %v", err)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -828,7 +828,7 @@ var (
 		Usage: "Catalyst mode (eth2 integration testing)",
 	}
 
-	BlockPruneAmountLeft = cli.Uint64Flag{
+	BlockAmountReserved = cli.Uint64Flag{
 		Name:  "block-amount-reserved",
 		Usage: "Sets the expected remained amount of blocks for offline block prune",
 	}
@@ -1888,7 +1888,7 @@ func SplitTagsFlag(tagsFlag string) map[string]string {
 }
 
 // MakeChainDatabase open an LevelDB using the flags passed to the client and will hard crash if it fails.
-func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly, isPruneBlock bool) ethdb.Database {
+func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly, disablFreeze bool) ethdb.Database {
 	var (
 		cache   = ctx.GlobalInt(CacheFlag.Name) * ctx.GlobalInt(CacheDatabaseFlag.Name) / 100
 		handles = MakeDatabaseHandles()
@@ -1901,7 +1901,7 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly, isPruneBloc
 		chainDb, err = stack.OpenDatabase(name, cache, handles, "", readonly)
 	} else {
 		name := "chaindata"
-		chainDb, err = stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", readonly, isPruneBlock)
+		chainDb, err = stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", readonly, disablFreeze)
 	}
 	if err != nil {
 		Fatalf("Could not open database: %v", err)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -829,7 +829,7 @@ var (
 	}
 
 	BlockPruneAmountLeft = cli.Uint64Flag{
-		Name:  "reserved-recent-blocks",
+		Name:  "block-amount-reserved",
 		Usage: "Sets the expected remained amount of blocks for offline block prune",
 	}
 )

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -322,9 +322,9 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 		rawdb.InitDatabaseFromFreezer(bc.db)
 		// If ancient database is not empty, reconstruct all missing
 		// indices in the background.
-		frozen, _ := bc.db.Ancients()
+		frozen, _ := bc.db.ItemAmountInAncient()
 		if frozen > 0 {
-			txIndexBlock = frozen
+			txIndexBlock, _ = bc.db.Ancients()
 		}
 	}
 	if err := bc.loadLastState(); err != nil {
@@ -359,7 +359,11 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 		}
 	}
 	// Ensure that a previous crash in SetHead doesn't leave extra ancients
-	if frozen, err := bc.db.Ancients(); err == nil && frozen > 0 {
+	if frozen, err := bc.db.ItemAmountInAncient(); err == nil && frozen > 0 {
+		frozen, err = bc.db.Ancients()
+		if err != nil {
+			return nil, err
+		}
 		var (
 			needRewind bool
 			low        uint64

--- a/core/blockchain_repair_test.go
+++ b/core/blockchain_repair_test.go
@@ -1762,7 +1762,7 @@ func testRepair(t *testing.T, tt *rewindTest, snapshots bool) {
 	}
 	os.RemoveAll(datadir)
 
-	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false)
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false)
 	if err != nil {
 		t.Fatalf("Failed to create persistent database: %v", err)
 	}
@@ -1832,7 +1832,7 @@ func testRepair(t *testing.T, tt *rewindTest, snapshots bool) {
 	db.Close()
 
 	// Start a new blockchain back up and see where the repait leads us
-	db, err = rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false)
+	db, err = rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false)
 	if err != nil {
 		t.Fatalf("Failed to reopen persistent database: %v", err)
 	}

--- a/core/blockchain_repair_test.go
+++ b/core/blockchain_repair_test.go
@@ -1762,7 +1762,7 @@ func testRepair(t *testing.T, tt *rewindTest, snapshots bool) {
 	}
 	os.RemoveAll(datadir)
 
-	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false)
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("Failed to create persistent database: %v", err)
 	}
@@ -1832,7 +1832,7 @@ func testRepair(t *testing.T, tt *rewindTest, snapshots bool) {
 	db.Close()
 
 	// Start a new blockchain back up and see where the repait leads us
-	db, err = rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false)
+	db, err = rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("Failed to reopen persistent database: %v", err)
 	}

--- a/core/blockchain_sethead_test.go
+++ b/core/blockchain_sethead_test.go
@@ -1961,7 +1961,7 @@ func testSetHead(t *testing.T, tt *rewindTest, snapshots bool) {
 	}
 	os.RemoveAll(datadir)
 
-	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false)
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false)
 	if err != nil {
 		t.Fatalf("Failed to create persistent database: %v", err)
 	}

--- a/core/blockchain_sethead_test.go
+++ b/core/blockchain_sethead_test.go
@@ -1961,7 +1961,7 @@ func testSetHead(t *testing.T, tt *rewindTest, snapshots bool) {
 	}
 	os.RemoveAll(datadir)
 
-	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false)
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("Failed to create persistent database: %v", err)
 	}

--- a/core/blockchain_snapshot_test.go
+++ b/core/blockchain_snapshot_test.go
@@ -64,7 +64,7 @@ func (basic *snapshotTestBasic) prepare(t *testing.T) (*BlockChain, []*types.Blo
 	}
 	os.RemoveAll(datadir)
 
-	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false)
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false)
 	if err != nil {
 		t.Fatalf("Failed to create persistent database: %v", err)
 	}
@@ -248,7 +248,7 @@ func (snaptest *crashSnapshotTest) test(t *testing.T) {
 	db.Close()
 
 	// Start a new blockchain back up and see where the repair leads us
-	newdb, err := rawdb.NewLevelDBDatabaseWithFreezer(snaptest.datadir, 0, 0, snaptest.datadir, "", false)
+	newdb, err := rawdb.NewLevelDBDatabaseWithFreezer(snaptest.datadir, 0, 0, snaptest.datadir, "", false, false)
 	if err != nil {
 		t.Fatalf("Failed to reopen persistent database: %v", err)
 	}

--- a/core/blockchain_snapshot_test.go
+++ b/core/blockchain_snapshot_test.go
@@ -64,7 +64,7 @@ func (basic *snapshotTestBasic) prepare(t *testing.T) (*BlockChain, []*types.Blo
 	}
 	os.RemoveAll(datadir)
 
-	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false)
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("Failed to create persistent database: %v", err)
 	}
@@ -248,7 +248,7 @@ func (snaptest *crashSnapshotTest) test(t *testing.T) {
 	db.Close()
 
 	// Start a new blockchain back up and see where the repair leads us
-	newdb, err := rawdb.NewLevelDBDatabaseWithFreezer(snaptest.datadir, 0, 0, snaptest.datadir, "", false, false)
+	newdb, err := rawdb.NewLevelDBDatabaseWithFreezer(snaptest.datadir, 0, 0, snaptest.datadir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("Failed to reopen persistent database: %v", err)
 	}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -653,7 +653,7 @@ func TestFastVsFullChains(t *testing.T) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(frdir)
-	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false)
+	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -727,7 +727,7 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 			t.Fatalf("failed to create temp freezer dir: %v", err)
 		}
 		defer os.Remove(dir)
-		db, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), dir, "", false)
+		db, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), dir, "", false, false)
 		if err != nil {
 			t.Fatalf("failed to create temp freezer db: %v", err)
 		}
@@ -1594,7 +1594,7 @@ func TestBlockchainRecovery(t *testing.T) {
 	}
 	defer os.Remove(frdir)
 
-	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false)
+	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -1651,7 +1651,7 @@ func TestIncompleteAncientReceiptChainInsertion(t *testing.T) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(frdir)
-	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false)
+	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -1850,7 +1850,7 @@ func testInsertKnownChainData(t *testing.T, typ string) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(dir)
-	chaindb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), dir, "", false)
+	chaindb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), dir, "", false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -2130,7 +2130,7 @@ func TestTransactionIndices(t *testing.T) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(frdir)
-	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false)
+	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -2158,7 +2158,7 @@ func TestTransactionIndices(t *testing.T) {
 	// Init block chain with external ancients, check all needed indices has been indexed.
 	limit := []uint64{0, 32, 64, 128}
 	for _, l := range limit {
-		ancientDb, err = rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false)
+		ancientDb, err = rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false)
 		if err != nil {
 			t.Fatalf("failed to create temp freezer db: %v", err)
 		}
@@ -2178,7 +2178,7 @@ func TestTransactionIndices(t *testing.T) {
 	}
 
 	// Reconstruct a block chain which only reserves HEAD-64 tx indices
-	ancientDb, err = rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false)
+	ancientDb, err = rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -2257,7 +2257,7 @@ func TestSkipStaleTxIndicesInFastSync(t *testing.T) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(frdir)
-	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false)
+	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -653,7 +653,7 @@ func TestFastVsFullChains(t *testing.T) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(frdir)
-	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false)
+	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -727,7 +727,7 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 			t.Fatalf("failed to create temp freezer dir: %v", err)
 		}
 		defer os.Remove(dir)
-		db, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), dir, "", false, false)
+		db, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), dir, "", false, false, false)
 		if err != nil {
 			t.Fatalf("failed to create temp freezer db: %v", err)
 		}
@@ -1594,7 +1594,7 @@ func TestBlockchainRecovery(t *testing.T) {
 	}
 	defer os.Remove(frdir)
 
-	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false)
+	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -1651,7 +1651,7 @@ func TestIncompleteAncientReceiptChainInsertion(t *testing.T) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(frdir)
-	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false)
+	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -1850,7 +1850,7 @@ func testInsertKnownChainData(t *testing.T, typ string) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(dir)
-	chaindb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), dir, "", false, false)
+	chaindb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), dir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -2130,7 +2130,7 @@ func TestTransactionIndices(t *testing.T) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(frdir)
-	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false)
+	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -2158,7 +2158,7 @@ func TestTransactionIndices(t *testing.T) {
 	// Init block chain with external ancients, check all needed indices has been indexed.
 	limit := []uint64{0, 32, 64, 128}
 	for _, l := range limit {
-		ancientDb, err = rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false)
+		ancientDb, err = rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false)
 		if err != nil {
 			t.Fatalf("failed to create temp freezer db: %v", err)
 		}
@@ -2178,7 +2178,7 @@ func TestTransactionIndices(t *testing.T) {
 	}
 
 	// Reconstruct a block chain which only reserves HEAD-64 tx indices
-	ancientDb, err = rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false)
+	ancientDb, err = rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -2257,7 +2257,7 @@ func TestSkipStaleTxIndicesInFastSync(t *testing.T) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(frdir)
-	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false)
+	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -294,6 +294,20 @@ func ReadHeaderRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValu
 	return nil // Can't find the data anywhere.
 }
 
+func ReadOffSetOfAncientFreezer(db ethdb.KeyValueStore) uint64 {
+	offset, _ := db.Get(offSetOfAncientFreezer)
+	if offset == nil {
+		return 0
+	}
+	return new(big.Int).SetBytes(offset).Uint64()
+}
+
+func WriteOffSetOfAncientFreezer(db ethdb.KeyValueStore, offset uint64) {
+	if err := db.Put(offSetOfAncientFreezer, new(big.Int).SetUint64(offset).Bytes()); err != nil {
+		log.Crit("Failed to store offSetOfAncientFreezer", "err", err)
+	}
+}
+
 // HasHeader verifies the existence of a block header corresponding to the hash.
 func HasHeader(db ethdb.Reader, hash common.Hash, number uint64) bool {
 	if has, err := db.Ancient(freezerHashTable, number); err == nil && common.BytesToHash(has) == hash {
@@ -723,7 +737,6 @@ func WriteAncientBlock(db ethdb.AncientWriter, block *types.Block, receipts type
 	}
 	return len(headerBlob) + len(bodyBlob) + len(receiptBlob) + len(tdBlob) + common.HashLength
 }
-
 
 // DeleteBlock removes all block data associated with a hash.
 func DeleteBlock(db ethdb.KeyValueWriter, hash common.Hash, number uint64) {

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -724,6 +724,7 @@ func WriteAncientBlock(db ethdb.AncientWriter, block *types.Block, receipts type
 	return len(headerBlob) + len(bodyBlob) + len(receiptBlob) + len(tdBlob) + common.HashLength
 }
 
+
 // DeleteBlock removes all block data associated with a hash.
 func DeleteBlock(db ethdb.KeyValueWriter, hash common.Hash, number uint64) {
 	DeleteReceipts(db, hash, number)

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -294,20 +294,6 @@ func ReadHeaderRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValu
 	return nil // Can't find the data anywhere.
 }
 
-func ReadOffSetOfAncientFreezer(db ethdb.KeyValueStore) uint64 {
-	offset, _ := db.Get(offSetOfAncientFreezer)
-	if offset == nil {
-		return 0
-	}
-	return new(big.Int).SetBytes(offset).Uint64()
-}
-
-func WriteOffSetOfAncientFreezer(db ethdb.KeyValueStore, offset uint64) {
-	if err := db.Put(offSetOfAncientFreezer, new(big.Int).SetUint64(offset).Bytes()); err != nil {
-		log.Crit("Failed to store offSetOfAncientFreezer", "err", err)
-	}
-}
-
 // HasHeader verifies the existence of a block header corresponding to the hash.
 func HasHeader(db ethdb.Reader, hash common.Hash, number uint64) bool {
 	if has, err := db.Ancient(freezerHashTable, number); err == nil && common.BytesToHash(has) == hash {

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -440,7 +440,7 @@ func TestAncientStorage(t *testing.T) {
 	}
 	defer os.Remove(frdir)
 
-	db, err := NewDatabaseWithFreezer(NewMemoryDatabase(), frdir, "", false)
+	db, err := NewDatabaseWithFreezer(NewMemoryDatabase(), frdir, "", false, false)
 	if err != nil {
 		t.Fatalf("failed to create database with ancient backend")
 	}

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -440,7 +440,7 @@ func TestAncientStorage(t *testing.T) {
 	}
 	defer os.Remove(frdir)
 
-	db, err := NewDatabaseWithFreezer(NewMemoryDatabase(), frdir, "", false, false)
+	db, err := NewDatabaseWithFreezer(NewMemoryDatabase(), frdir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create database with ancient backend")
 	}

--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -35,17 +35,18 @@ import (
 // injects into the database the block hash->number mappings.
 func InitDatabaseFromFreezer(db ethdb.Database) {
 	// If we can't access the freezer or it's empty, abort
-	frozen, err := db.Ancients()
+	frozen, err := db.ItemAmountInAncient()
 	if err != nil || frozen == 0 {
 		return
 	}
 	var (
-		batch  = db.NewBatch()
-		start  = time.Now()
-		logged = start.Add(-7 * time.Second) // Unindex during import is fast, don't double log
-		hash   common.Hash
+		batch     = db.NewBatch()
+		start     = time.Now()
+		logged    = start.Add(-7 * time.Second) // Unindex during import is fast, don't double log
+		hash      common.Hash
+		offset, _ = db.AncientOffSet()
 	)
-	for i := uint64(0); i < frozen; i++ {
+	for i := uint64(0) + offset; i < frozen+offset; i++ {
 		// Since the freezer has all data in sequential order on a file,
 		// it would be 'neat' to read more data in one go, and let the
 		// freezerdb return N items (e.g up to 1000 items per go)

--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -40,11 +40,11 @@ func InitDatabaseFromFreezer(db ethdb.Database) {
 		return
 	}
 	var (
-		batch     = db.NewBatch()
-		start     = time.Now()
-		logged    = start.Add(-7 * time.Second) // Unindex during import is fast, don't double log
-		hash      common.Hash
-		offset, _ = db.AncientOffSet()
+		batch  = db.NewBatch()
+		start  = time.Now()
+		logged = start.Add(-7 * time.Second) // Unindex during import is fast, don't double log
+		hash   common.Hash
+		offset = db.AncientOffSet()
 	)
 	for i := uint64(0) + offset; i < frozen+offset; i++ {
 		// Since the freezer has all data in sequential order on a file,

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -122,6 +122,11 @@ func (db *nofreezedb) AppendAncient(number uint64, hash, header, body, receipts,
 	return errNotSupported
 }
 
+// AppendAncientNoBody returns an error as we don't have a backing chain freezer.
+func (db *nofreezedb) AppendAncientNoBody(number uint64, hash, header, receipts, td []byte) error {
+	return errNotSupported
+}
+
 // TruncateAncients returns an error as we don't have a backing chain freezer.
 func (db *nofreezedb) TruncateAncients(items uint64) error {
 	return errNotSupported

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -122,11 +122,6 @@ func (db *nofreezedb) AppendAncient(number uint64, hash, header, body, receipts,
 	return errNotSupported
 }
 
-// AppendAncientNoBody returns an error as we don't have a backing chain freezer.
-func (db *nofreezedb) AppendAncientNoBody(number uint64, hash, header, receipts, td []byte) error {
-	return errNotSupported
-}
-
 // TruncateAncients returns an error as we don't have a backing chain freezer.
 func (db *nofreezedb) TruncateAncients(items uint64) error {
 	return errNotSupported
@@ -162,6 +157,7 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 	if err != nil {
 		return nil, err
 	}
+	offset := ReadOffSetOfAncientFreezer(db)
 	// Since the freezer can be stored separately from the user's key-value database,
 	// there's a fairly high probability that the user requests invalid combinations
 	// of the freezer and database. Ensure that we don't shoot ourselves in the foot
@@ -184,52 +180,90 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 	// If the genesis hash is empty, we have a new key-value store, so nothing to
 	// validate in this method. If, however, the genesis hash is not nil, compare
 	// it to the freezer content.
-	if kvgenesis, _ := db.Get(headerHashKey(0)); len(kvgenesis) > 0 {
-		if frozen, _ := frdb.Ancients(); frozen > 0 {
-			// If the freezer already contains something, ensure that the genesis blocks
-			// match, otherwise we might mix up freezers across chains and destroy both
-			// the freezer and the key-value store.
-			frgenesis, err := frdb.Ancient(freezerHashTable, 0)
-			if err != nil {
-				return nil, fmt.Errorf("failed to retrieve genesis from ancient %v", err)
-			} else if !bytes.Equal(kvgenesis, frgenesis) {
-				return nil, fmt.Errorf("genesis mismatch: %#x (leveldb) != %#x (ancients)", kvgenesis, frgenesis)
-			}
-			// Key-value store and freezer belong to the same network. Ensure that they
-			// are contiguous, otherwise we might end up with a non-functional freezer.
-			if kvhash, _ := db.Get(headerHashKey(frozen)); len(kvhash) == 0 {
-				// Subsequent header after the freezer limit is missing from the database.
-				// Reject startup is the database has a more recent head.
-				if *ReadHeaderNumber(db, ReadHeadHeaderHash(db)) > frozen-1 {
-					return nil, fmt.Errorf("gap (#%d) in the chain between ancients and leveldb", frozen)
+	if offset == 0 {
+		if kvgenesis, _ := db.Get(headerHashKey(0)); len(kvgenesis) > 0 {
+			if frozen, _ := frdb.Ancients(); frozen > 0 {
+				// If the freezer already contains something, ensure that the genesis blocks
+				// match, otherwise we might mix up freezers across chains and destroy both
+				// the freezer and the key-value store.
+				frgenesis, err := frdb.Ancient(freezerHashTable, 0)
+				if err != nil {
+					return nil, fmt.Errorf("failed to retrieve genesis from ancient %v", err)
+				} else if !bytes.Equal(kvgenesis, frgenesis) {
+					return nil, fmt.Errorf("genesis mismatch: %#x (leveldb) != %#x (ancients)", kvgenesis, frgenesis)
 				}
-				// Database contains only older data than the freezer, this happens if the
-				// state was wiped and reinited from an existing freezer.
-			}
-			// Otherwise, key-value store continues where the freezer left off, all is fine.
-			// We might have duplicate blocks (crash after freezer write but before key-value
-			// store deletion, but that's fine).
-		} else {
-			// If the freezer is empty, ensure nothing was moved yet from the key-value
-			// store, otherwise we'll end up missing data. We check block #1 to decide
-			// if we froze anything previously or not, but do take care of databases with
-			// only the genesis block.
-			if ReadHeadHeaderHash(db) != common.BytesToHash(kvgenesis) {
-				// Key-value store contains more data than the genesis block, make sure we
-				// didn't freeze anything yet.
-				if kvblob, _ := db.Get(headerHashKey(1)); len(kvblob) == 0 {
-					return nil, errors.New("ancient chain segments already extracted, please set --datadir.ancient to the correct path")
+				// Key-value store and freezer belong to the same network. Ensure that they
+				// are contiguous, otherwise we might end up with a non-functional freezer.
+				if kvhash, _ := db.Get(headerHashKey(frozen)); len(kvhash) == 0 {
+					// Subsequent header after the freezer limit is missing from the database.
+					// Reject startup is the database has a more recent head.
+					if *ReadHeaderNumber(db, ReadHeadHeaderHash(db)) > frozen-1 {
+						return nil, fmt.Errorf("gap (#%d) in the chain between ancients and leveldb", frozen)
+					}
+					// Database contains only older data than the freezer, this happens if the
+					// state was wiped and reinited from an existing freezer.
 				}
-				// Block #1 is still in the database, we're allowed to init a new feezer
+				// Otherwise, key-value store continues where the freezer left off, all is fine.
+				// We might have duplicate blocks (crash after freezer write but before key-value
+				// store deletion, but that's fine).
+			} else {
+				// If the freezer is empty, ensure nothing was moved yet from the key-value
+				// store, otherwise we'll end up missing data. We check block #1 to decide
+				// if we froze anything previously or not, but do take care of databases with
+				// only the genesis block.
+				if ReadHeadHeaderHash(db) != common.BytesToHash(kvgenesis) {
+					// Key-value store contains more data than the genesis block, make sure we
+					// didn't freeze anything yet.
+					if kvblob, _ := db.Get(headerHashKey(1)); len(kvblob) == 0 {
+						return nil, errors.New("ancient chain segments already extracted, please set --datadir.ancient to the correct path")
+					}
+					// Block #1 is still in the database, we're allowed to init a new feezer
+				}
+				// Otherwise, the head header is still the genesis, we're allowed to init a new
+				// feezer.
 			}
-			// Otherwise, the head header is still the genesis, we're allowed to init a new
-			// feezer.
 		}
 	}
 	// Freezer is consistent with the key-value database, permit combining the two
 	if !frdb.readonly {
 		go frdb.freeze(db)
 	}
+	return &freezerdb{
+		KeyValueStore: db,
+		AncientStore:  frdb,
+	}, nil
+}
+
+// NewDatabaseWithFreezer creates a high level database on top of a given key-
+// value data store with a freezer moving immutable chain segments into cold
+// storage.
+//Without goroutine of freeze running
+func NewDatabaseWithFreezerForPruneBlock(db ethdb.KeyValueStore, freezer string, namespace string, readonly bool) (ethdb.Database, error) {
+	// Create the idle freezer instance
+	frdb, err := newFreezer(freezer, namespace, readonly)
+	if err != nil {
+		return nil, err
+	}
+
+	return &freezerdb{
+		KeyValueStore: db,
+		AncientStore:  frdb,
+	}, nil
+}
+
+// NewDatabaseWithFreezer creates a high level database on top of a given key-
+// value data store with a freezer moving immutable chain segments into cold
+// storage.
+func NewDatabaseWithFreezerBackup(offset uint64, db ethdb.KeyValueStore, freezer string, namespace string, readonly bool) (ethdb.Database, error) {
+	// Create the idle freezer instance
+	frdb, err := newFreezer(freezer, namespace, readonly)
+	if err != nil {
+		return nil, err
+	}
+
+	//Assign the new offset to the new backup freezer while creating freezer
+	frdb.offset = offset
+
 	return &freezerdb{
 		KeyValueStore: db,
 		AncientStore:  frdb,
@@ -272,6 +306,37 @@ func NewLevelDBDatabaseWithFreezer(file string, cache int, handles int, freezer 
 		return nil, err
 	}
 	return frdb, nil
+}
+
+// NewLevelDBDatabaseWithFreezer creates a persistent key-value database with a
+// freezer moving immutable chain segments into cold storage.
+func NewLevelDBDatabaseWithFreezerForPruneBlock(file string, cache int, handles int, freezer string, namespace string, readonly bool) (ethdb.Database, error) {
+	kvdb, err := leveldb.New(file, cache, handles, namespace, readonly)
+	if err != nil {
+		return nil, err
+	}
+	frdb, err := NewDatabaseWithFreezerForPruneBlock(kvdb, freezer, namespace, readonly)
+	if err != nil {
+		kvdb.Close()
+		return nil, err
+	}
+	return frdb, nil
+}
+
+// NewLevelDBDatabaseWithFreezer creates a persistent key-value database with a
+// freezer moving immutable chain segments into cold storage.
+func NewLevelDBDatabaseWithFreezerBackup(offset uint64, file string, cache int, handles int, freezer string, namespace string, readonly bool) (ethdb.Database, error) {
+	kvdb, err := leveldb.New(file, cache, handles, namespace, readonly)
+	if err != nil {
+		return nil, err
+	}
+	db, err := NewDatabaseWithFreezerBackup(offset, kvdb, freezer, namespace, readonly)
+	if err != nil {
+		kvdb.Close()
+		return nil, err
+	}
+
+	return db, nil
 }
 
 type counter uint64

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -148,6 +148,16 @@ func NewDatabase(db ethdb.KeyValueStore) ethdb.Database {
 	}
 }
 
+//NewFreezerDb only create a freezer without statedb.
+func NewFreezerDb(freezer, namespace string, readonly bool) (*freezer, error) {
+	// Create the idle freezer instance
+	frdb, err := newFreezer(freezer, namespace, readonly)
+	if err != nil {
+		return nil, err
+	}
+	return frdb, nil
+}
+
 // NewDatabaseWithFreezer creates a high level database on top of a given key-
 // value data store with a freezer moving immutable chain segments into cold
 // storage.

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -151,9 +151,9 @@ func NewDatabase(db ethdb.KeyValueStore) ethdb.Database {
 // NewDatabaseWithFreezer creates a high level database on top of a given key-
 // value data store with a freezer moving immutable chain segments into cold
 // storage.
-func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace string, args ...bool) (ethdb.Database, error) {
+func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace string, readonly ...bool) (ethdb.Database, error) {
 	// Create the idle freezer instance
-	frdb, err := newFreezer(freezer, namespace, args[0])
+	frdb, err := newFreezer(freezer, namespace, readonly[0])
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +230,7 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 	}
 
 	// Freezer is consistent with the key-value database, permit combining the two
-	if len(args) == 1 && !frdb.readonly {
+	if len(readonly) == 1 && !frdb.readonly {
 		go frdb.freeze(db)
 	}
 	return &freezerdb{
@@ -264,12 +264,12 @@ func NewLevelDBDatabase(file string, cache int, handles int, namespace string, r
 
 // NewLevelDBDatabaseWithFreezer creates a persistent key-value database with a
 // freezer moving immutable chain segments into cold storage.
-func NewLevelDBDatabaseWithFreezer(file string, cache int, handles int, freezer string, namespace string, args ...bool) (ethdb.Database, error) {
-	kvdb, err := leveldb.New(file, cache, handles, namespace, args[0])
+func NewLevelDBDatabaseWithFreezer(file string, cache int, handles int, freezer string, namespace string, readonly ...bool) (ethdb.Database, error) {
+	kvdb, err := leveldb.New(file, cache, handles, namespace, readonly[0])
 	if err != nil {
 		return nil, err
 	}
-	frdb, err := NewDatabaseWithFreezer(kvdb, freezer, namespace, args...)
+	frdb, err := NewDatabaseWithFreezer(kvdb, freezer, namespace, readonly...)
 	if err != nil {
 		kvdb.Close()
 		return nil, err

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -151,13 +151,16 @@ func NewDatabase(db ethdb.KeyValueStore) ethdb.Database {
 // NewDatabaseWithFreezer creates a high level database on top of a given key-
 // value data store with a freezer moving immutable chain segments into cold
 // storage.
-func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace string, readonly bool) (ethdb.Database, error) {
+func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace string, args ...bool) (ethdb.Database, error) {
 	// Create the idle freezer instance
-	frdb, err := newFreezer(freezer, namespace, readonly)
+	frdb, err := newFreezer(freezer, namespace, args[0])
 	if err != nil {
 		return nil, err
 	}
 	offset := ReadOffSetOfAncientFreezer(db)
+
+	frdb.offset = offset
+
 	// Since the freezer can be stored separately from the user's key-value database,
 	// there's a fairly high probability that the user requests invalid combinations
 	// of the freezer and database. Ensure that we don't shoot ourselves in the foot
@@ -227,44 +230,9 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 		}
 	}
 	// Freezer is consistent with the key-value database, permit combining the two
-	if !frdb.readonly {
+	if len(args) == 1 && !frdb.readonly {
 		go frdb.freeze(db)
 	}
-	return &freezerdb{
-		KeyValueStore: db,
-		AncientStore:  frdb,
-	}, nil
-}
-
-// NewDatabaseWithFreezerForPruneBlock creates or open if existed a high level database on top of a given key-
-// value data store with a freezer, but without goroutine of freezer running to avoid the uncertainty
-// between kvdb and freezer goroutine when open/close db.
-func NewDatabaseWithFreezerForPruneBlock(db ethdb.KeyValueStore, freezer string, namespace string, readonly bool) (ethdb.Database, error) {
-	// Create the idle freezer instance
-	frdb, err := newFreezer(freezer, namespace, readonly)
-	if err != nil {
-		return nil, err
-	}
-
-	return &freezerdb{
-		KeyValueStore: db,
-		AncientStore:  frdb,
-	}, nil
-}
-
-// NewDatabaseWithFreezerBackup creates or open if existed a high level database on top of a given key-
-// value data store with a freezer, passed the params of offset, without goroutine of freezer running
-//to avoid the uncertainty between kvdb and freezer goroutine when open/close db
-func NewDatabaseWithFreezerBackup(offset uint64, db ethdb.KeyValueStore, freezer string, namespace string, readonly bool) (ethdb.Database, error) {
-	// Create the idle freezer instance
-	frdb, err := newFreezer(freezer, namespace, readonly)
-	if err != nil {
-		return nil, err
-	}
-
-	//Assign the new offset to the new backup freezer while creating freezer
-	frdb.offset = offset
-
 	return &freezerdb{
 		KeyValueStore: db,
 		AncientStore:  frdb,
@@ -296,48 +264,17 @@ func NewLevelDBDatabase(file string, cache int, handles int, namespace string, r
 
 // NewLevelDBDatabaseWithFreezer creates a persistent key-value database with a
 // freezer moving immutable chain segments into cold storage.
-func NewLevelDBDatabaseWithFreezer(file string, cache int, handles int, freezer string, namespace string, readonly bool) (ethdb.Database, error) {
-	kvdb, err := leveldb.New(file, cache, handles, namespace, readonly)
+func NewLevelDBDatabaseWithFreezer(file string, cache int, handles int, freezer string, namespace string, args ...bool) (ethdb.Database, error) {
+	kvdb, err := leveldb.New(file, cache, handles, namespace, args[0])
 	if err != nil {
 		return nil, err
 	}
-	frdb, err := NewDatabaseWithFreezer(kvdb, freezer, namespace, readonly)
-	if err != nil {
-		kvdb.Close()
-		return nil, err
-	}
-	return frdb, nil
-}
-
-// NewLevelDBDatabaseWithFreezerForPruneBlock creates a persistent key-value database with a
-// freezer.
-func NewLevelDBDatabaseWithFreezerForPruneBlock(file string, cache int, handles int, freezer string, namespace string, readonly bool) (ethdb.Database, error) {
-	kvdb, err := leveldb.New(file, cache, handles, namespace, readonly)
-	if err != nil {
-		return nil, err
-	}
-	frdb, err := NewDatabaseWithFreezerForPruneBlock(kvdb, freezer, namespace, readonly)
+	frdb, err := NewDatabaseWithFreezer(kvdb, freezer, namespace, args...)
 	if err != nil {
 		kvdb.Close()
 		return nil, err
 	}
 	return frdb, nil
-}
-
-// NewLevelDBDatabaseWithFreezerBackup creates a persistent key-value database with a
-// freezer.
-func NewLevelDBDatabaseWithFreezerBackup(offset uint64, file string, cache int, handles int, freezer string, namespace string, readonly bool) (ethdb.Database, error) {
-	kvdb, err := leveldb.New(file, cache, handles, namespace, readonly)
-	if err != nil {
-		return nil, err
-	}
-	db, err := NewDatabaseWithFreezerBackup(offset, kvdb, freezer, namespace, readonly)
-	if err != nil {
-		kvdb.Close()
-		return nil, err
-	}
-
-	return db, nil
 }
 
 type counter uint64

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -320,6 +320,7 @@ func (s *stat) Count() string {
 // InspectDatabase traverses the entire database and checks the size
 // of all different categories of data.
 func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
+	offset := counter(ReadOffSetOfAncientFreezer(db))
 	it := db.NewIterator(keyPrefix, keyStart)
 	defer it.Release()
 
@@ -452,6 +453,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 	if count, err := db.Ancients(); err == nil {
 		ancients = counter(count)
 	}
+
 	// Display the database statistic.
 	stats := [][]string{
 		{"Key-Value store", "Headers", headers.Size(), headers.Count()},
@@ -478,6 +480,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		{"Ancient store", "Block number->hash", ancientHashesSize.String(), ancients.String()},
 		{"Light client", "CHT trie nodes", chtTrieNodes.Size(), chtTrieNodes.Count()},
 		{"Light client", "Bloom trie nodes", bloomTrieNodes.Size(), bloomTrieNodes.Count()},
+		{"Offset/StartBlockNumber", "Offset of AncientStore", "", offset.String()},
 	}
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"Database", "Category", "Size", "Items"})

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -151,9 +151,9 @@ func NewDatabase(db ethdb.KeyValueStore) ethdb.Database {
 // NewDatabaseWithFreezer creates a high level database on top of a given key-
 // value data store with a freezer moving immutable chain segments into cold
 // storage.
-func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace string, readonly ...bool) (ethdb.Database, error) {
+func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace string, readonly, isPruneBlock bool) (ethdb.Database, error) {
 	// Create the idle freezer instance
-	frdb, err := newFreezer(freezer, namespace, readonly[0])
+	frdb, err := newFreezer(freezer, namespace, readonly)
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +230,7 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 	}
 
 	// Freezer is consistent with the key-value database, permit combining the two
-	if len(readonly) == 1 && !frdb.readonly {
+	if !isPruneBlock && !frdb.readonly {
 		go frdb.freeze(db)
 	}
 	return &freezerdb{
@@ -264,12 +264,12 @@ func NewLevelDBDatabase(file string, cache int, handles int, namespace string, r
 
 // NewLevelDBDatabaseWithFreezer creates a persistent key-value database with a
 // freezer moving immutable chain segments into cold storage.
-func NewLevelDBDatabaseWithFreezer(file string, cache int, handles int, freezer string, namespace string, readonly ...bool) (ethdb.Database, error) {
-	kvdb, err := leveldb.New(file, cache, handles, namespace, readonly[0])
+func NewLevelDBDatabaseWithFreezer(file string, cache int, handles int, freezer string, namespace string, readonly, isPruneBlock bool) (ethdb.Database, error) {
+	kvdb, err := leveldb.New(file, cache, handles, namespace, readonly)
 	if err != nil {
 		return nil, err
 	}
-	frdb, err := NewDatabaseWithFreezer(kvdb, freezer, namespace, readonly...)
+	frdb, err := NewDatabaseWithFreezer(kvdb, freezer, namespace, readonly, isPruneBlock)
 	if err != nil {
 		kvdb.Close()
 		return nil, err

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -185,50 +185,50 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 	// it to the freezer content.
 	// Only to check the followings when offset equal to 0, otherwise the block number
 	// in ancientdb did not start with 0, no genesis block in ancientdb as well.
-	if offset == 0 {
-		if kvgenesis, _ := db.Get(headerHashKey(0)); len(kvgenesis) > 0 {
-			if frozen, _ := frdb.Ancients(); frozen > 0 {
-				// If the freezer already contains something, ensure that the genesis blocks
-				// match, otherwise we might mix up freezers across chains and destroy both
-				// the freezer and the key-value store.
-				frgenesis, err := frdb.Ancient(freezerHashTable, 0)
-				if err != nil {
-					return nil, fmt.Errorf("failed to retrieve genesis from ancient %v", err)
-				} else if !bytes.Equal(kvgenesis, frgenesis) {
-					return nil, fmt.Errorf("genesis mismatch: %#x (leveldb) != %#x (ancients)", kvgenesis, frgenesis)
-				}
-				// Key-value store and freezer belong to the same network. Ensure that they
-				// are contiguous, otherwise we might end up with a non-functional freezer.
-				if kvhash, _ := db.Get(headerHashKey(frozen)); len(kvhash) == 0 {
-					// Subsequent header after the freezer limit is missing from the database.
-					// Reject startup is the database has a more recent head.
-					if *ReadHeaderNumber(db, ReadHeadHeaderHash(db)) > frozen-1 {
-						return nil, fmt.Errorf("gap (#%d) in the chain between ancients and leveldb", frozen)
-					}
-					// Database contains only older data than the freezer, this happens if the
-					// state was wiped and reinited from an existing freezer.
-				}
-				// Otherwise, key-value store continues where the freezer left off, all is fine.
-				// We might have duplicate blocks (crash after freezer write but before key-value
-				// store deletion, but that's fine).
-			} else {
-				// If the freezer is empty, ensure nothing was moved yet from the key-value
-				// store, otherwise we'll end up missing data. We check block #1 to decide
-				// if we froze anything previously or not, but do take care of databases with
-				// only the genesis block.
-				if ReadHeadHeaderHash(db) != common.BytesToHash(kvgenesis) {
-					// Key-value store contains more data than the genesis block, make sure we
-					// didn't freeze anything yet.
-					if kvblob, _ := db.Get(headerHashKey(1)); len(kvblob) == 0 {
-						return nil, errors.New("ancient chain segments already extracted, please set --datadir.ancient to the correct path")
-					}
-					// Block #1 is still in the database, we're allowed to init a new feezer
-				}
-				// Otherwise, the head header is still the genesis, we're allowed to init a new
-				// feezer.
+
+	if kvgenesis, _ := db.Get(headerHashKey(0)); offset == 0 && len(kvgenesis) > 0 {
+		if frozen, _ := frdb.Ancients(); frozen > 0 {
+			// If the freezer already contains something, ensure that the genesis blocks
+			// match, otherwise we might mix up freezers across chains and destroy both
+			// the freezer and the key-value store.
+			frgenesis, err := frdb.Ancient(freezerHashTable, 0)
+			if err != nil {
+				return nil, fmt.Errorf("failed to retrieve genesis from ancient %v", err)
+			} else if !bytes.Equal(kvgenesis, frgenesis) {
+				return nil, fmt.Errorf("genesis mismatch: %#x (leveldb) != %#x (ancients)", kvgenesis, frgenesis)
 			}
+			// Key-value store and freezer belong to the same network. Ensure that they
+			// are contiguous, otherwise we might end up with a non-functional freezer.
+			if kvhash, _ := db.Get(headerHashKey(frozen)); len(kvhash) == 0 {
+				// Subsequent header after the freezer limit is missing from the database.
+				// Reject startup is the database has a more recent head.
+				if *ReadHeaderNumber(db, ReadHeadHeaderHash(db)) > frozen-1 {
+					return nil, fmt.Errorf("gap (#%d) in the chain between ancients and leveldb", frozen)
+				}
+				// Database contains only older data than the freezer, this happens if the
+				// state was wiped and reinited from an existing freezer.
+			}
+			// Otherwise, key-value store continues where the freezer left off, all is fine.
+			// We might have duplicate blocks (crash after freezer write but before key-value
+			// store deletion, but that's fine).
+		} else {
+			// If the freezer is empty, ensure nothing was moved yet from the key-value
+			// store, otherwise we'll end up missing data. We check block #1 to decide
+			// if we froze anything previously or not, but do take care of databases with
+			// only the genesis block.
+			if ReadHeadHeaderHash(db) != common.BytesToHash(kvgenesis) {
+				// Key-value store contains more data than the genesis block, make sure we
+				// didn't freeze anything yet.
+				if kvblob, _ := db.Get(headerHashKey(1)); len(kvblob) == 0 {
+					return nil, errors.New("ancient chain segments already extracted, please set --datadir.ancient to the correct path")
+				}
+				// Block #1 is still in the database, we're allowed to init a new feezer
+			}
+			// Otherwise, the head header is still the genesis, we're allowed to init a new
+			// feezer.
 		}
 	}
+
 	// Freezer is consistent with the key-value database, permit combining the two
 	if len(args) == 1 && !frdb.readonly {
 		go frdb.freeze(db)

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -180,6 +180,8 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 	// If the genesis hash is empty, we have a new key-value store, so nothing to
 	// validate in this method. If, however, the genesis hash is not nil, compare
 	// it to the freezer content.
+	// Only to check the followings when offset equal to 0, otherwise the block number
+	// in ancientdb did not start with 0, no genesis block in ancientdb as well.
 	if offset == 0 {
 		if kvgenesis, _ := db.Get(headerHashKey(0)); len(kvgenesis) > 0 {
 			if frozen, _ := frdb.Ancients(); frozen > 0 {
@@ -234,10 +236,9 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 	}, nil
 }
 
-// NewDatabaseWithFreezer creates a high level database on top of a given key-
-// value data store with a freezer moving immutable chain segments into cold
-// storage.
-//Without goroutine of freeze running
+// NewDatabaseWithFreezerForPruneBlock creates or open if existed a high level database on top of a given key-
+// value data store with a freezer, but without goroutine of freezer running to avoid the uncertainty
+// between kvdb and freezer goroutine when open/close db.
 func NewDatabaseWithFreezerForPruneBlock(db ethdb.KeyValueStore, freezer string, namespace string, readonly bool) (ethdb.Database, error) {
 	// Create the idle freezer instance
 	frdb, err := newFreezer(freezer, namespace, readonly)
@@ -251,9 +252,9 @@ func NewDatabaseWithFreezerForPruneBlock(db ethdb.KeyValueStore, freezer string,
 	}, nil
 }
 
-// NewDatabaseWithFreezer creates a high level database on top of a given key-
-// value data store with a freezer moving immutable chain segments into cold
-// storage.
+// NewDatabaseWithFreezerBackup creates or open if existed a high level database on top of a given key-
+// value data store with a freezer, passed the params of offset, without goroutine of freezer running
+//to avoid the uncertainty between kvdb and freezer goroutine when open/close db
 func NewDatabaseWithFreezerBackup(offset uint64, db ethdb.KeyValueStore, freezer string, namespace string, readonly bool) (ethdb.Database, error) {
 	// Create the idle freezer instance
 	frdb, err := newFreezer(freezer, namespace, readonly)
@@ -308,8 +309,8 @@ func NewLevelDBDatabaseWithFreezer(file string, cache int, handles int, freezer 
 	return frdb, nil
 }
 
-// NewLevelDBDatabaseWithFreezer creates a persistent key-value database with a
-// freezer moving immutable chain segments into cold storage.
+// NewLevelDBDatabaseWithFreezerForPruneBlock creates a persistent key-value database with a
+// freezer.
 func NewLevelDBDatabaseWithFreezerForPruneBlock(file string, cache int, handles int, freezer string, namespace string, readonly bool) (ethdb.Database, error) {
 	kvdb, err := leveldb.New(file, cache, handles, namespace, readonly)
 	if err != nil {
@@ -323,8 +324,8 @@ func NewLevelDBDatabaseWithFreezerForPruneBlock(file string, cache int, handles 
 	return frdb, nil
 }
 
-// NewLevelDBDatabaseWithFreezer creates a persistent key-value database with a
-// freezer moving immutable chain segments into cold storage.
+// NewLevelDBDatabaseWithFreezerBackup creates a persistent key-value database with a
+// freezer.
 func NewLevelDBDatabaseWithFreezerBackup(offset uint64, file string, cache int, handles int, freezer string, namespace string, readonly bool) (ethdb.Database, error) {
 	kvdb, err := leveldb.New(file, cache, handles, namespace, readonly)
 	if err != nil {

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -185,6 +185,7 @@ func NewFreezerDb(db ethdb.KeyValueStore, frz, namespace string, readonly bool, 
 		return nil, errors
 	}
 	frdb.offset = newOffSet
+	frdb.frozen += newOffSet
 	return frdb, nil
 }
 
@@ -207,6 +208,10 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 	}
 
 	frdb.offset = offset
+
+	// Some blocks in ancientDB may have already been frozen and been pruned, so adding the offset to
+	// reprensent the absolute number of blocks already frozen.
+	frdb.frozen += offset
 
 	// Since the freezer can be stored separately from the user's key-value database,
 	// there's a fairly high probability that the user requests invalid combinations
@@ -355,7 +360,7 @@ func (s *stat) Count() string {
 }
 func AncientInspect(db ethdb.Database) error {
 	offset := counter(ReadOffSetOfCurrentAncientFreezer(db))
-	// Get number of ancient rows inside the freezer
+	// Get number of ancient rows inside the freezer.
 	ancients := counter(0)
 	if count, err := db.Ancients(); err == nil {
 		ancients = counter(count)

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -209,7 +209,7 @@ func NewFreezerDb(db ethdb.KeyValueStore, frz, namespace string, readonly bool, 
 // NewDatabaseWithFreezer creates a high level database on top of a given key-
 // value data store with a freezer moving immutable chain segments into cold
 // storage.
-func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace string, readonly, disablFreeze bool) (ethdb.Database, error) {
+func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace string, readonly, disableFreeze bool) (ethdb.Database, error) {
 	// Create the idle freezer instance
 	frdb, err := newFreezer(freezer, namespace, readonly)
 	if err != nil {
@@ -303,7 +303,7 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 	}
 
 	// Freezer is consistent with the key-value database, permit combining the two
-	if !disablFreeze && !frdb.readonly {
+	if !disableFreeze && !frdb.readonly {
 		go frdb.freeze(db)
 	}
 	return &freezerdb{
@@ -337,12 +337,12 @@ func NewLevelDBDatabase(file string, cache int, handles int, namespace string, r
 
 // NewLevelDBDatabaseWithFreezer creates a persistent key-value database with a
 // freezer moving immutable chain segments into cold storage.
-func NewLevelDBDatabaseWithFreezer(file string, cache int, handles int, freezer string, namespace string, readonly, disablFreeze bool) (ethdb.Database, error) {
+func NewLevelDBDatabaseWithFreezer(file string, cache int, handles int, freezer string, namespace string, readonly, disableFreeze bool) (ethdb.Database, error) {
 	kvdb, err := leveldb.New(file, cache, handles, namespace, readonly)
 	if err != nil {
 		return nil, err
 	}
-	frdb, err := NewDatabaseWithFreezer(kvdb, freezer, namespace, readonly, disablFreeze)
+	frdb, err := NewDatabaseWithFreezer(kvdb, freezer, namespace, readonly, disableFreeze)
 	if err != nil {
 		kvdb.Close()
 		return nil, err

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -360,9 +360,11 @@ func AncientInspect(db ethdb.Database) error {
 	if count, err := db.Ancients(); err == nil {
 		ancients = counter(count)
 	}
+	endNumber := offset + ancients - 1
 	stats := [][]string{
-		{"Offset/StartBlockNumber", "Offset/StartBlockNumber after BlockPrune", offset.String()},
-		{"Amount of remained items in AncientStore", "remaining items after BlockPrune", ancients.String()},
+		{"Offset/StartBlockNumber", "Offset/StartBlockNumber of ancientDB", offset.String()},
+		{"Amount of remained items in AncientStore", "Remaining items of ancientDB", ancients.String()},
+		{"The last BlockNumber within ancientDB", "The last BlockNumber", endNumber.String()},
 	}
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"Database", "Category", "Items"})

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -147,8 +147,8 @@ func (db *nofreezedb) SetDiffStore(diff ethdb.KeyValueStore) {
 	db.diffStore = diff
 }
 
-func (db *nofreezedb) AncientOffSet() (uint64, error) {
-	return 0, nil
+func (db *nofreezedb) AncientOffSet() uint64 {
+	return 0
 }
 
 // NewDatabase creates a high level database on top of a given key-value data

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -189,9 +189,9 @@ func WriteOffSetOfLastAncientFreezer(db ethdb.KeyValueWriter, offset uint64) {
 // NewFreezerDb only create a freezer without statedb.
 func NewFreezerDb(db ethdb.KeyValueStore, frz, namespace string, readonly bool, newOffSet uint64) (*freezer, error) {
 	// Create the idle freezer instance, this operation should be atomic to avoid mismatch between offset and acientDB.
-	frdb, errors := newFreezer(frz, namespace, readonly)
-	if errors != nil {
-		return nil, errors
+	frdb, err := newFreezer(frz, namespace, readonly)
+	if err != nil {
+		return nil, err
 	}
 	frdb.offset = newOffSet
 	frdb.frozen += newOffSet
@@ -371,7 +371,10 @@ func AncientInspect(db ethdb.Database) error {
 	offset := counter(ReadOffSetOfCurrentAncientFreezer(db))
 	// Get number of ancient rows inside the freezer.
 	ancients := counter(0)
-	if count, err := db.ItemAmountInAncient(); err == nil {
+	if count, err := db.ItemAmountInAncient(); err != nil {
+		log.Error("failed to get the items amount in ancientDB", "err", err)
+		return err
+	} else {
 		ancients = counter(count)
 	}
 	var endNumber counter

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -240,6 +240,53 @@ func (f *freezer) AppendAncient(number uint64, hash, header, body, receipts, td 
 	return nil
 }
 
+// AppendAncient injects all binary blobs except for block body at the end of the
+// append-only immutable table files.
+//
+// Notably, this function is lock free but kind of thread-safe. All out-of-order
+// injection will be rejected. But if two injections with same number happen at
+// the same time, we can get into the trouble.
+func (f *freezer) AppendAncientNoBody(number uint64, hash, header, receipts, td []byte) (err error) {
+	if f.readonly {
+		return errReadOnly
+	}
+	// Ensure the binary blobs we are appending is continuous with freezer.
+	if atomic.LoadUint64(&f.frozen) != number {
+		return errOutOrderInsertion
+	}
+	// Rollback all inserted data if any insertion below failed to ensure
+	// the tables won't out of sync.
+	defer func() {
+		if err != nil {
+			rerr := f.repair()
+			if rerr != nil {
+				log.Crit("Failed to repair freezer", "err", rerr)
+			}
+			log.Info("Append ancient failed", "number", number, "err", err)
+		}
+	}()
+	// Inject all the components into the relevant data tables
+	if err := f.tables[freezerHashTable].Append(f.frozen, hash[:]); err != nil {
+		log.Error("Failed to append ancient hash", "number", f.frozen, "hash", hash, "err", err)
+		return err
+	}
+	if err := f.tables[freezerHeaderTable].Append(f.frozen, header); err != nil {
+		log.Error("Failed to append ancient header", "number", f.frozen, "hash", hash, "err", err)
+		return err
+	}
+
+	if err := f.tables[freezerReceiptTable].Append(f.frozen, receipts); err != nil {
+		log.Error("Failed to append ancient receipts", "number", f.frozen, "hash", hash, "err", err)
+		return err
+	}
+	if err := f.tables[freezerDifficultyTable].Append(f.frozen, td); err != nil {
+		log.Error("Failed to append ancient difficulty", "number", f.frozen, "hash", hash, "err", err)
+		return err
+	}
+	atomic.AddUint64(&f.frozen, 1) // Only modify atomically
+	return nil
+}
+
 // TruncateAncients discards any recent data above the provided threshold number.
 func (f *freezer) TruncateAncients(items uint64) error {
 	if f.readonly {

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -142,11 +142,6 @@ func newFreezer(datadir string, namespace string, readonly bool) (*freezer, erro
 	return freezer, nil
 }
 
-func (f *freezer) SetOffSet(offset uint64) error {
-	f.offset = offset
-	return nil
-}
-
 // Close terminates the chain freezer, unmapping all the data files.
 func (f *freezer) Close() error {
 	var errs []error

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -181,7 +181,17 @@ func (f *freezer) Ancient(kind string, number uint64) ([]byte, error) {
 
 // Ancients returns the length of the frozen items.
 func (f *freezer) Ancients() (uint64, error) {
+	return atomic.LoadUint64(&f.frozen), nil
+}
+
+// ItemAmountInAncient returns the actual length of current ancientDB.
+func (f *freezer) ItemAmountInAncient() (uint64, error) {
 	return atomic.LoadUint64(&f.frozen) - atomic.LoadUint64(&f.offset), nil
+}
+
+// AncientOffSet returns the offset of current ancientDB.
+func (f *freezer) AncientOffSet() (uint64, error) {
+	return atomic.LoadUint64(&f.offset), nil
 }
 
 // AncientSize returns the ancient size of the specified category.
@@ -251,7 +261,7 @@ func (f *freezer) TruncateAncients(items uint64) error {
 		return nil
 	}
 	for _, table := range f.tables {
-		if err := table.truncate(items); err != nil {
+		if err := table.truncate(items - f.offset); err != nil {
 			return err
 		}
 	}

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -190,8 +190,8 @@ func (f *freezer) ItemAmountInAncient() (uint64, error) {
 }
 
 // AncientOffSet returns the offset of current ancientDB.
-func (f *freezer) AncientOffSet() (uint64, error) {
-	return atomic.LoadUint64(&f.offset), nil
+func (f *freezer) AncientOffSet() uint64 {
+	return atomic.LoadUint64(&f.offset)
 }
 
 // AncientSize returns the ancient size of the specified category.

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -69,6 +69,7 @@ var (
 	// fastTxLookupLimitKey tracks the transaction lookup limit during fast sync.
 	fastTxLookupLimitKey = []byte("FastTransactionLookupLimit")
 
+	offSetOfAncientFreezer = []byte("OffSetOfAncientFreezer")
 	// badBlockKey tracks the list of bad blocks seen by local
 	badBlockKey = []byte("InvalidBlock")
 

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -69,7 +69,12 @@ var (
 	// fastTxLookupLimitKey tracks the transaction lookup limit during fast sync.
 	fastTxLookupLimitKey = []byte("FastTransactionLookupLimit")
 
-	offSetOfAncientFreezer = []byte("OffSetOfAncientFreezer")
+	//offSet of new updated ancientDB.
+	offSetOfCurrentAncientFreezer = []byte("offSetOfCurrentAncientFreezer")
+
+	//offSet of the ancientDB before updated version.
+	offSetOfLastAncientFreezer = []byte("offSetOfLastAncientFreezer")
+
 	// badBlockKey tracks the list of bad blocks seen by local
 	badBlockKey = []byte("InvalidBlock")
 

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -74,7 +74,7 @@ func (t *table) ItemAmountInAncient() (uint64, error) {
 }
 
 // AncientOffSet returns the offset of current ancientDB.
-func (t *table) AncientOffSet() (uint64, error) {
+func (t *table) AncientOffSet() uint64 {
 	return t.db.AncientOffSet()
 }
 

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -68,6 +68,16 @@ func (t *table) Ancients() (uint64, error) {
 	return t.db.Ancients()
 }
 
+// ItemAmountInAncient returns the actual length of current ancientDB.
+func (t *table) ItemAmountInAncient() (uint64, error) {
+	return t.db.ItemAmountInAncient()
+}
+
+// AncientOffSet returns the offset of current ancientDB.
+func (t *table) AncientOffSet() (uint64, error) {
+	return t.db.AncientOffSet()
+}
+
 // AncientSize is a noop passthrough that just forwards the request to the underlying
 // database.
 func (t *table) AncientSize(kind string) (uint64, error) {

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -285,7 +285,7 @@ func (p *BlockPruner) backUpOldDb(name string, cache, handles int, namespace str
 	}
 
 	oldOffSet := rawdb.ReadOffSetOfAncientFreezer(chainDb)
-	// Get the actual start block number.
+	// Get the start BlockNumber for pruning.
 	startBlockNumber := oldOffSet + frozen - p.BlockPruneAmountLeft
 	// For every round, newoffset actually equals to the startBlockNumber in ancient backup db.
 	frdbBack.SetOffSet(startBlockNumber)

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -129,7 +129,6 @@ func NewPruner(db ethdb.Database, datadir, trieCachePath string, bloomSize, trie
 }
 
 func NewBlockPruner(db ethdb.Database, n *node.Node, oldAncientPath, newAncientPath string) (*BlockPruner, error) {
-
 	return &BlockPruner{
 		db:             db,
 		oldAncientPath: oldAncientPath,

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -255,8 +255,8 @@ func prune(snaptree *snapshot.Tree, root common.Hash, maindb ethdb.Database, sta
 	return nil
 }
 
-func (p *BlockPruner) backUpOldDb(name string, cache, handles int, freezer, namespace string, args ...bool) ([]*types.Block, []types.Receipts, []*big.Int, error) {
-	chainDb, err := p.node.OpenDatabaseWithFreezer(name, cache, handles, freezer, namespace, args...)
+func (p *BlockPruner) backUpOldDb(name string, cache, handles int, freezer, namespace string, readonly bool) ([]*types.Block, []types.Receipts, []*big.Int, error) {
+	chainDb, err := p.node.OpenDatabaseWithFreezer(name, cache, handles, freezer, namespace, readonly, true)
 	if err != nil {
 		log.Error("Failed to open ancient database", "err=", err)
 		return nil, nil, nil, err
@@ -308,7 +308,7 @@ func (p *BlockPruner) BlockPruneBackUp(name string, cache, handles int, namespac
 
 	start := time.Now()
 
-	blockList, receiptsList, externTdList, err := p.backUpOldDb(name, cache, handles, p.oldAncientPath, namespace, readonly, true)
+	blockList, receiptsList, externTdList, err := p.backUpOldDb(name, cache, handles, p.oldAncientPath, namespace, readonly)
 	if err != nil {
 		return err
 	}

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -371,13 +371,12 @@ func (p *BlockPruner) RecoverInterruption(name string, cache, handles int, names
 
 	if newExist {
 		log.Info("New ancientDB_backup existed in interruption scenario")
-		var flockOfAncientBack bool
-		if exist, err := CheckFileExist(filepath.Join(p.newAncientPath, "PRUNEFLOCKBACK")); err != nil {
+		flockOfAncientBack, err := CheckFileExist(filepath.Join(p.newAncientPath, "PRUNEFLOCKBACK"))
+		if err != nil {
 			log.Error("Failed to check flock of ancientDB_Back %v", err)
 			return err
-		} else {
-			flockOfAncientBack = exist
 		}
+
 		// Indicating both old and new ancientDB existed concurrently.
 		// Delete directly for the new ancientdb to prune from start, e.g.: path ../chaindb/ancient_backup
 		if err := os.RemoveAll(p.newAncientPath); err != nil {

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -129,14 +129,14 @@ func NewPruner(db ethdb.Database, datadir, trieCachePath string, bloomSize, trie
 	}, nil
 }
 
-func NewBlockPruner(db ethdb.Database, n *node.Node, oldAncientPath, newAncientPath string, BlockAmountReserved uint64) (*BlockPruner, error) {
+func NewBlockPruner(db ethdb.Database, n *node.Node, oldAncientPath, newAncientPath string, BlockAmountReserved uint64) *BlockPruner {
 	return &BlockPruner{
 		db:                  db,
 		oldAncientPath:      oldAncientPath,
 		newAncientPath:      newAncientPath,
 		node:                n,
 		BlockAmountReserved: BlockAmountReserved,
-	}, nil
+	}
 }
 
 func prune(snaptree *snapshot.Tree, root common.Hash, maindb ethdb.Database, stateBloom *stateBloom, bloomPath string, middleStateRoots map[common.Hash]struct{}, start time.Time) error {
@@ -425,7 +425,7 @@ func (p *BlockPruner) RecoverInterruption(name string, cache, handles int, names
 func CheckFileExist(path string) (bool, error) {
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
-			//Indicating the file didn't exist.
+			// Indicating the file didn't exist.
 			return false, nil
 		}
 		return true, err

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -112,6 +112,7 @@ func NewPruner(db ethdb.Database, datadir, trieCachePath string, bloomSize, trie
 		bloomSize = 256
 	}
 	stateBloom, err := newStateBloomWithSize(bloomSize)
+
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +327,7 @@ func (p *BlockPruner) backUpOldDb(name string, cache, handles int, namespace str
 
 		//Write into new ancient_back db.
 		rawdb.WriteAncientBlock(frdbBack, block, receipts, externTd)
-		log.Info("backup blockNumber successfully", "blockNumber", blockNumber)
+		log.Info("backup block successfully", "blockNumber", blockNumber)
 	}
 
 	return nil

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/big"
 	"os"
 	"path/filepath"
 	"strings"
@@ -336,10 +335,8 @@ func (p *BlockPruner) backUpOldDb(name string, cache, handles int, namespace str
 		if td == nil {
 			return consensus.ErrUnknownAncestor
 		}
-		externTd := new(big.Int).Add(block.Difficulty(), td)
-
 		// Write into new ancient_back db.
-		rawdb.WriteAncientBlock(frdbBack, block, receipts, externTd)
+		rawdb.WriteAncientBlock(frdbBack, block, receipts, td)
 		// Print the log every 5s for better trace.
 		if common.PrettyDuration(time.Since(start)) > common.PrettyDuration(5*time.Second) {
 			log.Info("block backup process running successfully", "current blockNumber for backup", blockNumber)

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -599,10 +599,10 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.I
 			d.ancientLimit = 0
 		}
 		frozen, _ := d.stateDB.Ancients() // Ignore the error here since light client can also hit here.
-
+		itemAmountInAncient, _ := d.stateDB.ItemAmountInAncient()
 		// If a part of blockchain data has already been written into active store,
 		// disable the ancient style insertion explicitly.
-		if origin >= frozen && frozen != 0 {
+		if origin >= frozen && itemAmountInAncient != 0 {
 			d.ancientLimit = 0
 			log.Info("Disabling direct-ancient mode", "origin", origin, "ancient", frozen-1)
 		} else if d.ancientLimit > 0 {

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -95,9 +95,6 @@ type AncientWriter interface {
 	// Sync flushes all in-memory ancient store data to disk.
 	Sync() error
 
-	// AppendAncient injects all binary blobs except for block body at the end of the
-	// append-only immutable table files.
-	AppendAncientNoBody(number uint64, hash, header, receipts, td []byte) error
 }
 
 // Reader contains the methods required to read data from both key-value as well as

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -94,7 +94,6 @@ type AncientWriter interface {
 
 	// Sync flushes all in-memory ancient store data to disk.
 	Sync() error
-
 }
 
 // Reader contains the methods required to read data from both key-value as well as

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -94,6 +94,10 @@ type AncientWriter interface {
 
 	// Sync flushes all in-memory ancient store data to disk.
 	Sync() error
+
+	// AppendAncient injects all binary blobs except for block body at the end of the
+	// append-only immutable table files.
+	AppendAncientNoBody(number uint64, hash, header, receipts, td []byte) error
 }
 
 // Reader contains the methods required to read data from both key-value as well as

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -81,6 +81,12 @@ type AncientReader interface {
 
 	// AncientSize returns the ancient size of the specified category.
 	AncientSize(kind string) (uint64, error)
+
+	// ItemAmountInAncient returns the actual length of current ancientDB.
+	ItemAmountInAncient() (uint64, error)
+
+	// AncientOffSet returns the offset of current ancientDB.
+	AncientOffSet() (uint64, error)
 }
 
 // AncientWriter contains the methods required to write to immutable ancient data.

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -86,7 +86,7 @@ type AncientReader interface {
 	ItemAmountInAncient() (uint64, error)
 
 	// AncientOffSet returns the offset of current ancientDB.
-	AncientOffSet() (uint64, error)
+	AncientOffSet() uint64
 }
 
 // AncientWriter contains the methods required to write to immutable ancient data.

--- a/node/node.go
+++ b/node/node.go
@@ -606,7 +606,7 @@ func (n *Node) OpenAndMergeDatabase(name string, cache, handles int, freezer, di
 // also attaching a chain freezer to it that moves ancient chain data from the
 // database to immutable append-only files. If the node is an ephemeral one, a
 // memory database is returned.
-func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer, namespace string, readonly bool) (ethdb.Database, error) {
+func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer, namespace string, args ...bool) (ethdb.Database, error) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 	if n.state == closedState {
@@ -625,74 +625,7 @@ func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer,
 		case !filepath.IsAbs(freezer):
 			freezer = n.ResolvePath(freezer)
 		}
-		db, err = rawdb.NewLevelDBDatabaseWithFreezer(root, cache, handles, freezer, namespace, readonly)
-	}
-
-	if err == nil {
-		db = n.wrapDatabase(db)
-	}
-	return db, err
-}
-
-// The big difference is that the freezer inside was not running to avoid the mess between kvdb and freezer
-// while opening/closing db.
-// OpenDatabaseWithFreezerForPruneBlock opens an existing database with the given name (or
-// creates one if no previous can be found) from within the node's data directory,
-// also attaching a chain freezer to it. If the node is an ephemeral one, a memory database is returned.
-func (n *Node) OpenDatabaseWithFreezerForPruneBlock(name string, cache, handles int, freezer, namespace string, readonly bool) (ethdb.Database, error) {
-	n.lock.Lock()
-	defer n.lock.Unlock()
-	if n.state == closedState {
-		return nil, ErrNodeStopped
-	}
-
-	var db ethdb.Database
-	var err error
-	if n.config.DataDir == "" {
-		db = rawdb.NewMemoryDatabase()
-	} else {
-		root := n.ResolvePath(name)
-		switch {
-		case freezer == "":
-			freezer = filepath.Join(root, "ancient")
-		case !filepath.IsAbs(freezer):
-			freezer = n.ResolvePath(freezer)
-		}
-		db, err = rawdb.NewLevelDBDatabaseWithFreezerForPruneBlock(root, cache, handles, freezer, namespace, readonly)
-	}
-
-	if err == nil {
-		db = n.wrapDatabase(db)
-	}
-	return db, err
-}
-
-// The big difference is that the freezer inside was not running to avoid the mess between kvdb and freezer
-// while opening/closing db.
-// OpenDatabaseWithFreezerBackup opens an existing database with the given name (or
-// creates one if no previous can be found) from within the node's data directory,
-// also attaching a chain freezer to it. If the node is an ephemeral one, a
-// memory database is returned.
-func (n *Node) OpenDatabaseWithFreezerBackup(offset uint64, name string, cache, handles int, freezer, namespace string, readonly bool) (ethdb.Database, error) {
-	n.lock.Lock()
-	defer n.lock.Unlock()
-	if n.state == closedState {
-		return nil, ErrNodeStopped
-	}
-
-	var db ethdb.Database
-	var err error
-	if n.config.DataDir == "" {
-		db = rawdb.NewMemoryDatabase()
-	} else {
-		root := n.ResolvePath(name)
-		switch {
-		case freezer == "":
-			freezer = filepath.Join(root, "ancient")
-		case !filepath.IsAbs(freezer):
-			freezer = n.ResolvePath(freezer)
-		}
-		db, err = rawdb.NewLevelDBDatabaseWithFreezerBackup(offset, root, cache, handles, freezer, namespace, readonly)
+		db, err = rawdb.NewLevelDBDatabaseWithFreezer(root, cache, handles, freezer, namespace, args...)
 	}
 
 	if err == nil {

--- a/node/node.go
+++ b/node/node.go
@@ -606,7 +606,7 @@ func (n *Node) OpenAndMergeDatabase(name string, cache, handles int, freezer, di
 // also attaching a chain freezer to it that moves ancient chain data from the
 // database to immutable append-only files. If the node is an ephemeral one, a
 // memory database is returned.
-func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer, namespace string, args ...bool) (ethdb.Database, error) {
+func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer, namespace string, readonly ...bool) (ethdb.Database, error) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 	if n.state == closedState {
@@ -625,7 +625,7 @@ func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer,
 		case !filepath.IsAbs(freezer):
 			freezer = n.ResolvePath(freezer)
 		}
-		db, err = rawdb.NewLevelDBDatabaseWithFreezer(root, cache, handles, freezer, namespace, args...)
+		db, err = rawdb.NewLevelDBDatabaseWithFreezer(root, cache, handles, freezer, namespace, readonly...)
 	}
 
 	if err == nil {

--- a/node/node.go
+++ b/node/node.go
@@ -586,7 +586,7 @@ func (n *Node) OpenAndMergeDatabase(name string, cache, handles int, freezer, di
 	if persistDiff {
 		chainDataHandles = handles * chainDataHandlesPercentage / 100
 	}
-	chainDB, err := n.OpenDatabaseWithFreezer(name, cache, chainDataHandles, freezer, namespace, readonly)
+	chainDB, err := n.OpenDatabaseWithFreezer(name, cache, chainDataHandles, freezer, namespace, readonly, false)
 	if err != nil {
 		return nil, err
 	}
@@ -606,7 +606,7 @@ func (n *Node) OpenAndMergeDatabase(name string, cache, handles int, freezer, di
 // also attaching a chain freezer to it that moves ancient chain data from the
 // database to immutable append-only files. If the node is an ephemeral one, a
 // memory database is returned.
-func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer, namespace string, readonly ...bool) (ethdb.Database, error) {
+func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer, namespace string, readonly, isPruneBlock bool) (ethdb.Database, error) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 	if n.state == closedState {
@@ -625,7 +625,7 @@ func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer,
 		case !filepath.IsAbs(freezer):
 			freezer = n.ResolvePath(freezer)
 		}
-		db, err = rawdb.NewLevelDBDatabaseWithFreezer(root, cache, handles, freezer, namespace, readonly...)
+		db, err = rawdb.NewLevelDBDatabaseWithFreezer(root, cache, handles, freezer, namespace, readonly, isPruneBlock)
 	}
 
 	if err == nil {

--- a/node/node.go
+++ b/node/node.go
@@ -634,11 +634,11 @@ func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer,
 	return db, err
 }
 
-// OpenDatabaseWithFreezer opens an existing database with the given name (or
+// The big difference is that the freezer inside was not running to avoid the mess between kvdb and freezer
+// while opening/closing db.
+// OpenDatabaseWithFreezerForPruneBlock opens an existing database with the given name (or
 // creates one if no previous can be found) from within the node's data directory,
-// also attaching a chain freezer to it that moves ancient chain data from the
-// database to immutable append-only files. If the node is an ephemeral one, a
-// memory database is returned.
+// also attaching a chain freezer to it. If the node is an ephemeral one, a memory database is returned.
 func (n *Node) OpenDatabaseWithFreezerForPruneBlock(name string, cache, handles int, freezer, namespace string, readonly bool) (ethdb.Database, error) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
@@ -667,10 +667,11 @@ func (n *Node) OpenDatabaseWithFreezerForPruneBlock(name string, cache, handles 
 	return db, err
 }
 
-// OpenDatabaseWithFreezer opens an existing database with the given name (or
+// The big difference is that the freezer inside was not running to avoid the mess between kvdb and freezer
+// while opening/closing db.
+// OpenDatabaseWithFreezerBackup opens an existing database with the given name (or
 // creates one if no previous can be found) from within the node's data directory,
-// also attaching a chain freezer to it that moves ancient chain data from the
-// database to immutable append-only files. If the node is an ephemeral one, a
+// also attaching a chain freezer to it. If the node is an ephemeral one, a
 // memory database is returned.
 func (n *Node) OpenDatabaseWithFreezerBackup(offset uint64, name string, cache, handles int, freezer, namespace string, readonly bool) (ethdb.Database, error) {
 	n.lock.Lock()

--- a/node/node.go
+++ b/node/node.go
@@ -606,7 +606,7 @@ func (n *Node) OpenAndMergeDatabase(name string, cache, handles int, freezer, di
 // also attaching a chain freezer to it that moves ancient chain data from the
 // database to immutable append-only files. If the node is an ephemeral one, a
 // memory database is returned.
-func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer, namespace string, readonly, disablFreeze bool) (ethdb.Database, error) {
+func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer, namespace string, readonly, disableFreeze bool) (ethdb.Database, error) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 	if n.state == closedState {
@@ -625,7 +625,7 @@ func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer,
 		case !filepath.IsAbs(freezer):
 			freezer = n.ResolvePath(freezer)
 		}
-		db, err = rawdb.NewLevelDBDatabaseWithFreezer(root, cache, handles, freezer, namespace, readonly, disablFreeze)
+		db, err = rawdb.NewLevelDBDatabaseWithFreezer(root, cache, handles, freezer, namespace, readonly, disableFreeze)
 	}
 
 	if err == nil {

--- a/node/node.go
+++ b/node/node.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/prometheus/tsdb/fileutil"
+
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -35,7 +37,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/prometheus/tsdb/fileutil"
 )
 
 // Node is a container on which services can be registered.

--- a/node/node.go
+++ b/node/node.go
@@ -606,7 +606,7 @@ func (n *Node) OpenAndMergeDatabase(name string, cache, handles int, freezer, di
 // also attaching a chain freezer to it that moves ancient chain data from the
 // database to immutable append-only files. If the node is an ephemeral one, a
 // memory database is returned.
-func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer, namespace string, readonly, isPruneBlock bool) (ethdb.Database, error) {
+func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer, namespace string, readonly, disablFreeze bool) (ethdb.Database, error) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 	if n.state == closedState {
@@ -625,7 +625,7 @@ func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer,
 		case !filepath.IsAbs(freezer):
 			freezer = n.ResolvePath(freezer)
 		}
-		db, err = rawdb.NewLevelDBDatabaseWithFreezer(root, cache, handles, freezer, namespace, readonly, isPruneBlock)
+		db, err = rawdb.NewLevelDBDatabaseWithFreezer(root, cache, handles, freezer, namespace, readonly, disablFreeze)
 	}
 
 	if err == nil {

--- a/node/node.go
+++ b/node/node.go
@@ -587,7 +587,7 @@ func (n *Node) OpenAndMergeDatabase(name string, cache, handles int, freezer, di
 	if persistDiff {
 		chainDataHandles = handles * chainDataHandlesPercentage / 100
 	}
-	chainDB, err := n.OpenDatabaseWithFreezer(name, cache, chainDataHandles, freezer, namespace, readonly, false)
+	chainDB, err := n.OpenDatabaseWithFreezer(name, cache, chainDataHandles, freezer, namespace, readonly, false, false)
 	if err != nil {
 		return nil, err
 	}
@@ -607,7 +607,7 @@ func (n *Node) OpenAndMergeDatabase(name string, cache, handles int, freezer, di
 // also attaching a chain freezer to it that moves ancient chain data from the
 // database to immutable append-only files. If the node is an ephemeral one, a
 // memory database is returned.
-func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer, namespace string, readonly, disableFreeze bool) (ethdb.Database, error) {
+func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer, namespace string, readonly, disableFreeze, isLastOffset bool) (ethdb.Database, error) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 	if n.state == closedState {
@@ -626,7 +626,7 @@ func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer,
 		case !filepath.IsAbs(freezer):
 			freezer = n.ResolvePath(freezer)
 		}
-		db, err = rawdb.NewLevelDBDatabaseWithFreezer(root, cache, handles, freezer, namespace, readonly, disableFreeze)
+		db, err = rawdb.NewLevelDBDatabaseWithFreezer(root, cache, handles, freezer, namespace, readonly, disableFreeze, isLastOffset)
 	}
 
 	if err == nil {

--- a/rlp/safe.go
+++ b/rlp/safe.go
@@ -22,5 +22,5 @@ import "reflect"
 
 // byteArrayBytes returns a slice of the byte array v.
 func byteArrayBytes(v reflect.Value) []byte {
-    return v.Slice(0, v.Len()).Bytes()
+	return v.Slice(0, v.Len()).Bytes()
 }

--- a/tests/fuzzers/bls12381/bls12381_fuzz.go
+++ b/tests/fuzzers/bls12381/bls12381_fuzz.go
@@ -28,6 +28,7 @@ import (
 	gnark "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fp"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+
 	"github.com/ethereum/go-ethereum/crypto/bls12381"
 )
 
@@ -159,7 +160,7 @@ func FuzzCrossG1MultiExp(data []byte) int {
 		gethPoints = append(gethPoints, new(bls12381.PointG1).Set(kp1))
 		gnarkPoints = append(gnarkPoints, *cp1)
 	}
-	if len(gethScalars) == 0{
+	if len(gethScalars) == 0 {
 		return 0
 	}
 	// compute multi exponentiation


### PR DESCRIPTION
### Description
This is for the off-line block prune, in bsc storage, there's db wrapper of ancientDb(freezer) and kvDb(levelDB), the space was mainly occupied by ancientDb, the purpose of this is to prune and remain the specific number of old blocks in ancientDb by specifying the amount of blocks you'd like to remain after pruning in the CLI flag. Then the pruner will prune and only remain this specified amount backward, this first block is not necessarily the genesis block because we may prune many rounds. Actually we can prune and remain any amount of blocks as long as the amount specified did exceed the number of blocks inside ancientDb
###Example:
Assume all blocks in ancientDb are [0,1,... 1000], if pruning amount of 500 blocks, then [0,...499] will be pruned, the data in ancientDb will be [500, 1000]. The next round for pruning will start with BlockNumber 500.
### Brief Coding workflow is as follows
1. Create a new ancientDb without a kvdb wrapper, it will create a new folder ./node/geth/chaindata/ancient_backup for initializing new ancientDb.
2. Back-up all the blocks at and after oldOffSet + frozen - BlockPruneAmountLeft from old ancientDb into new ancientBackup. In this process, pruner will read one by one for block, receipts, difficulty from old ancientDb and write to new backup ancientDb. To be noted that there’ll be a new offset of new ancientDb, this offset will be recorded into kvdb.
3. Delete directly for the old folder./node/geth /chaindata/ancient/, i.e. the old ancientDb.
4. Rename the new folder of ./node/geth/chaindata/ancient_backup into ./node/geth/chaindata/ancient, then assemble with the same kvdb of the original DB wrapper in which old ancientDb resides.
5. Finally the ancientDb in DB wrapper is replaced successfully, all the block data we want to reserve were in this new ancientDb.

### Self Test
1. Unit test: Initialized a blockchain of 500 blocks, testing the pruning of 328 amount of blocks remaining. passed
2. Locally geth test, start a full node: `./geth --config ./config.toml --datadir ./node --cache 12000 --rpc.allow-unprotected-txs --txlookuplimit 0 --syncmode full --usb`, after a while until there's enough old block for pruning in ancientDb. 
3. 1st round of prune test: Start the prune process:  `./geth snapshot prune-block --datadir ./node --datadir.ancient  ./chaindata/ancient --block-amount-reserved 10000`. This will prune and reserve 10000 blocks.
Passed and get a new ancientDb with amount of 10000 blocks
4. 2nd round of prune test, start the geth again, repeat the step 2 & 3.
5. Introduced the flag `inspect-reserved-oldest-blocks`,  can be used for checking information of ancientStore like offset and reserved items amount after pruning done. 
`./geth db inspect-reserved-oldest-blocks --datadir ./node`
+--------------------------------+--------------------------------+--------+
|            DATABASE            |            CATEGORY            | ITEMS  |
+--------------------------------+--------------------------------+--------+
| Offset/StartBlockNumber        | Offset/StartBlockNumber after  | 302672 |
|                                                    | BlockPrune                                   |               |
| Amount of remained items in  | remaining items after                   |  10000  |
| AncientStore                             | BlockPrune                                   |               |
+--------------------------------+--------------------------------+--------+
|                                  ANCIENTSTORE INFORMATION AFTER        |
|                                        OFFLINE BLOCKPRUNE                            |
+--------------------------------+--------------------------------+--------+
### Running command
e.g.
`./geth snapshot prune-block --datadir ./node --datadir.ancient ./chaindata/ancient  --block-amount-reserved 9000 --triesInMemory 32 --check-snapshot-with-mpt`
--block-amount-reserved: Amount of blocks want to reserve.
--triesInMemory(optional): The layer of tries trees that keep in memory.
--check-snapshot-with-mpt(optinal): Indicate if enable/disable checking for the match between MPT and snapshot.

Check the info of ancientDB
`./geth db inspect-reserved-oldest-blocks --datadir ./node`
### Result
1. The offset of ancientDb changed as expected.
2. Geth client restarted successfully.
3. new block data freeze() moving from kvDb to ancientDb as expected.
### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] manual transaction test passed
