### PR TITLE
Release v1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+## v1.1.5
+BUGFIX
+* [\#509](https://github.com/binance-chain/bsc/pull/509) fix graceful shutdown bug
+
+IMPROVEMENT
+* [\#536](https://github.com/binance-chain/bsc/pull/536) get diff accounts by replaying block when diff layer not found
+* [\#527](https://github.com/binance-chain/bsc/pull/527) improve diffsync protocol in many aspects
+* [\#493](https://github.com/binance-chain/bsc/pull/493) implement fast getDiffAccountsWithScope API
+
 ## v1.1.4
 Improvement
 * [\#472](https://github.com/binance-chain/bsc/pull/472) add metrics for contract code bitmap cache

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1011,7 +1011,7 @@ func (bc *BlockChain) GetDiffAccounts(blockHash common.Hash) ([]common.Address, 
 
 	if diffLayer == nil {
 		if header.TxHash != types.EmptyRootHash {
-			return nil, fmt.Errorf("no diff layer found")
+			return nil, ErrDiffLayerNotFound
 		}
 
 		return nil, nil

--- a/core/error.go
+++ b/core/error.go
@@ -31,6 +31,9 @@ var (
 
 	// ErrNoGenesis is returned when there is no Genesis Block.
 	ErrNoGenesis = errors.New("genesis not found in chain")
+
+	// ErrDiffLayerNotFound is returned when diff layer not found.
+	ErrDiffLayerNotFound = errors.New("diff layer not found")
 )
 
 // List of evm-call-message pre-checking errors. All state transition messages will

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1493,3 +1493,11 @@ func (s *StateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addre
 	}
 	return s.accessList.Contains(addr, slot)
 }
+
+func (s *StateDB) GetDirtyAccounts() []common.Address {
+	accounts := make([]common.Address, 0, len(s.stateObjectsDirty))
+	for account := range s.stateObjectsDirty {
+		accounts = append(accounts, account)
+	}
+	return accounts
+}

--- a/params/config.go
+++ b/params/config.go
@@ -250,7 +250,7 @@ var (
 		RamanujanBlock:      big.NewInt(0),
 		NielsBlock:          big.NewInt(0),
 		MirrorSyncBlock:     big.NewInt(5184000),
-		BrunoBlock:          nil,
+		BrunoBlock:          big.NewInt(13082000),
 		Parlia: &ParliaConfig{
 			Period: 3,
 			Epoch:  200,

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 1  // Minor version component of the current release
-	VersionPatch = 4  // Patch version component of the current release
+	VersionPatch = 5  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description

v1.1.5 is a hard fork release. 

v1.1.5 brings Bruno hard fork which introduces a real-time burning mechanism into the economic model of BSC. Please refer to BEP95 for more details. The Bruno hard fork is expected to happen at block height xxx. The current block generation speed forecasts this to occur around November 30th at 08:00 AM (UTC). All clients are recommended to upgrade by November 30th.

We improved the diffsync protocol in this release and rolled it out as a stable feature. Diff sync improves the syncing speed by 60%～70% approximately according to the test. All full nodes are suggested to enable it by adding `--diffsync` in the starting command. Refer to BEP93 for more details.

## Changelog since last upgrade

BUGFIX
* [\#509](https://github.com/binance-chain/bsc/pull/509) fix graceful shutdown bug

IMPROVEMENT
* [\#536](https://github.com/binance-chain/bsc/pull/536) get diff accounts by replaying block when diff layer not found
* [\#527](https://github.com/binance-chain/bsc/pull/527) improve diffsync protocol in many aspects
* [\#493](https://github.com/binance-chain/bsc/pull/493) implement fast getDiffAccountsWithScope API

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
