### PR TITLE
[R4R]reannounce local pending transactions

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -90,6 +90,7 @@ var (
 		utils.TxPoolAccountQueueFlag,
 		utils.TxPoolGlobalQueueFlag,
 		utils.TxPoolLifetimeFlag,
+		utils.TxPoolReannounceTimeFlag,
 		utils.SyncModeFlag,
 		utils.ExitWhenSyncedFlag,
 		utils.GCModeFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -108,6 +108,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.TxPoolAccountQueueFlag,
 			utils.TxPoolGlobalQueueFlag,
 			utils.TxPoolLifetimeFlag,
+			utils.TxPoolReannounceTimeFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -398,6 +398,11 @@ var (
 		Usage: "Maximum amount of time non-executable transaction are queued",
 		Value: ethconfig.Defaults.TxPool.Lifetime,
 	}
+	TxPoolReannounceTimeFlag = cli.DurationFlag{
+		Name:  "txpool.reannouncetime",
+		Usage: "Duration for announcing local pending transactions again (default = 10 years, minimum = 1 minute)",
+		Value: ethconfig.Defaults.TxPool.ReannounceTime,
+	}
 	// Performance tuning settings
 	CacheFlag = cli.IntFlag{
 		Name:  "cache",
@@ -1409,6 +1414,9 @@ func setTxPool(ctx *cli.Context, cfg *core.TxPoolConfig) {
 	}
 	if ctx.GlobalIsSet(TxPoolLifetimeFlag.Name) {
 		cfg.Lifetime = ctx.GlobalDuration(TxPoolLifetimeFlag.Name)
+	}
+	if ctx.GlobalIsSet(TxPoolReannounceTimeFlag.Name) {
+		cfg.ReannounceTime = ctx.GlobalDuration(TxPoolReannounceTimeFlag.Name)
 	}
 }
 

--- a/core/events.go
+++ b/core/events.go
@@ -24,6 +24,9 @@ import (
 // NewTxsEvent is posted when a batch of transactions enter the transaction pool.
 type NewTxsEvent struct{ Txs []*types.Transaction }
 
+// ReannoTxsEvent is posted when a batch of local pending transactions exceed a specified duration.
+type ReannoTxsEvent struct{ Txs []*types.Transaction }
+
 // NewMinedBlockEvent is posted when a block has been imported.
 type NewMinedBlockEvent struct{ Block *types.Block }
 

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -82,6 +82,11 @@ type TxData interface {
 	setSignatureValues(chainID, v, r, s *big.Int)
 }
 
+// Time returns transaction's time
+func (tx *Transaction) Time() time.Time {
+	return tx.time
+}
+
 // EncodeRLP implements rlp.Encoder
 func (tx *Transaction) EncodeRLP(w io.Writer) error {
 	if tx.Type() == LegacyTxType {

--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -266,6 +266,22 @@ func (ps *peerSet) peer(id string) *ethPeer {
 	return ps.peers[id]
 }
 
+// headPeers retrieves a specified number list of peers.
+func (ps *peerSet) headPeers(num uint) []*ethPeer {
+	ps.lock.RLock()
+	defer ps.lock.RUnlock()
+
+	if num > uint(len(ps.peers)) {
+		num = uint(len(ps.peers))
+	}
+
+	list := make([]*ethPeer, 0, num)
+	for _, p := range ps.peers {
+		list = append(list, p)
+	}
+	return list
+}
+
 // peersWithoutBlock retrieves a list of peers that do not have a given block in
 // their set of known hashes so it might be propagated to them.
 func (ps *peerSet) peersWithoutBlock(hash common.Hash) []*ethPeer {


### PR DESCRIPTION
### Description

When the network traffic is heavy, transactions that have been broadcast may be truncated in peers' tx_pools, while these local pending transactions have been marked as known, the source node won't broadcast them again, so they have no chance to be mined. 

We add a timer to check whether the local pending transactions stay in tx_pool exceed a threshold, once transactions exceed the threshold, they will be announced to some peers again. The  TxPool.ReannounceTime is used to control the threshold,  the default value of TxPool.ReannounceTime is too big to be exceeded, users can config this parameter to enable this feature.

Also need to pay attention, this feature only announce the local pending transactions. If your node is configured TxPool.NoLocals=false, then the transactions sent to this RPC node will be treated as local transactions, otherwise you should add your addresses to the TxPool.Locals, only the transactions from the local addresses will be treated as local transactions.

### Rationale

This feature is introduced to handle some extreme situations, it won't affect the original function, and it is disabled by default. Users can enable this feature by setting TxPool.ReannouceTime according to their needs.

### Example
Set TxPool.ReannounceTime to 5 minutes:
geth --config ./config.toml --datadir ./node  --cache 8000 --rpc.allow-unprotected-txs --txlookuplimit 0 --txpool.reannouncetime 5m

### Changes

Notable changes: 
* add --txpool.reannouncetime parameter, default value is 10 years, minimum value is 1 minute.
