### PR TITLE
[R4R]remove unnecessary part in PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -16,16 +16,3 @@ Notable changes:
 * add each change in a bullet point here
 * ...
 
-### Preflight checks
-
-- [ ] build passed (`make build`)
-- [ ] tests passed (`make test`)
-- [ ] manual transaction test passed
-
-### Already reviewed by
-
-...
-
-### Related issues
-
-... reference related issue #'s here ...


### PR DESCRIPTION
### Description
We just remove the unnecessary parts of our PR template, as we have a fine CI/CD workflow now.

### Rationale
1. `Preflight checks` is unnecessary because we get CI/CD checks now.
2. `Already reviewed by ` is unnecessary, since the reviewer would approve the PR if it is ok.
3. `Related issues` is unnecessary, since we should attach the issue in the description part.
### Example
No

### Changes
No

