### PR TITLE
Optimized db storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,5 @@ profile.cov
 /dashboard/assets/bundle.js
 /dashboard/assets/bundle.js.map
 /dashboard/assets/package-lock.json
-
+.history/
 **/yarn-error.log

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -446,7 +446,7 @@ func TestAncientStorage(t *testing.T) {
 	}
 	// Create a test block
 	block := types.NewBlockWithHeader(&types.Header{
-		Number:      big.NewInt(0),
+		Number:      big.NewInt(1),
 		Extra:       []byte("test block"),
 		UncleHash:   types.EmptyUncleHash,
 		TxHash:      types.EmptyRootHash,

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -184,7 +184,7 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 			// If the freezer already contains something, ensure that the genesis blocks
 			// match, otherwise we might mix up freezers across chains and destroy both
 			// the freezer and the key-value store.
-			frgenesis, err := frdb.Ancient(freezerHashTable, 0)
+			frgenesis, err := db.Get(headerHashKey(0))
 			if err != nil {
 				return nil, fmt.Errorf("failed to retrieve genesis from ancient %v", err)
 			} else if !bytes.Equal(kvgenesis, frgenesis) {
@@ -192,15 +192,15 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 			}
 			// Key-value store and freezer belong to the same network. Ensure that they
 			// are contiguous, otherwise we might end up with a non-functional freezer.
-			if kvhash, _ := db.Get(headerHashKey(frozen)); len(kvhash) == 0 {
-				// Subsequent header after the freezer limit is missing from the database.
-				// Reject startup is the database has a more recent head.
-				if *ReadHeaderNumber(db, ReadHeadHeaderHash(db)) > frozen-1 {
-					return nil, fmt.Errorf("gap (#%d) in the chain between ancients and leveldb", frozen)
-				}
-				// Database contains only older data than the freezer, this happens if the
-				// state was wiped and reinited from an existing freezer.
-			}
+			// if kvhash, _ := db.Get(headerHashKey(frozen)); len(kvhash) == 0 {
+			// 	// Subsequent header after the freezer limit is missing from the database.
+			// 	// Reject startup is the database has a more recent head.
+			// 	if *ReadHeaderNumber(db, ReadHeadHeaderHash(db)) > frozen-1 {
+			// 		return nil, fmt.Errorf("gap (#%d) in the chain between ancients and leveldb", frozen)
+			// 	}
+			// 	// Database contains only older data than the freezer, this happens if the
+			// 	// state was wiped and reinited from an existing freezer.
+			// }
 			// Otherwise, key-value store continues where the freezer left off, all is fine.
 			// We might have duplicate blocks (crash after freezer write but before key-value
 			// store deletion, but that's fine).
@@ -222,9 +222,9 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 		}
 	}
 	// Freezer is consistent with the key-value database, permit combining the two
-	if !frdb.readonly {
-		go frdb.freeze(db)
-	}
+	// if !frdb.readonly {
+	// 	go frdb.freeze(db)
+	// }
 	return &freezerdb{
 		KeyValueStore: db,
 		AncientStore:  frdb,

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -171,6 +171,9 @@ func (f *freezer) HasAncient(kind string, number uint64) (bool, error) {
 
 // Ancient retrieves an ancient binary blob from the append-only immutable files.
 func (f *freezer) Ancient(kind string, number uint64) ([]byte, error) {
+	if number < 0 {
+		return nil, errors.New("redirect the query to statedb")
+	}
 	if table := f.tables[kind]; table != nil {
 		return table.Retrieve(number)
 	}
@@ -201,7 +204,7 @@ func (f *freezer) AppendAncient(number uint64, hash, header, body, receipts, td 
 		return errReadOnly
 	}
 	// Ensure the binary blobs we are appending is continuous with freezer.
-	if atomic.LoadUint64(&f.frozen) != number {
+	if atomic.LoadUint64(&f.frozen) != number-1 {
 		return errOutOrderInsertion
 	}
 	// Rollback all inserted data if any insertion below failed to ensure


### PR DESCRIPTION
This PR re-opened and refined the change from PR:
https://github.com/binance-chain/bsc/pull/384
This is the optimization for database storage

Rationale
Block data is written to leveldb for two times. It occupied too much disk bandwidth. And as block data is sequential and less read operations, compaction to block data also takes disk bandwidth/ cpu/ memory.
State data in KV Store needs to do compaction in order to get better read performance. If block data and state data in the same KV Store, compaction will take more time(more data/ cpu/ memory/ disk bandwidth). Indeed we just need current world state(or latest world state) to execute. In future we needs other solution to get better performance.

- [x] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] manual transaction test passed

I/O test in AWS test machine:
From test, the I/O performance improved roughly 1/3 comparing with the old way

Pending for the stress test from QA team