### PR TITLE
[R4R] pre-release ci flow

### DIFF
--- a/.github/generate_change_log.sh
+++ b/.github/generate_change_log.sh
@@ -15,7 +15,7 @@ while read line; do
     if [[ $line == *"$version_prefix"* ]] && [ $start == 1 ]; then
         break;
     fi
-    if [ $start == 1 ] && [[ $line != "" ]]; then
+    if [ $start == 1 ]; then
         CHANGE_LOG+="$line\n"
     fi
 done < ${change_log_file}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,10 +1,9 @@
-name: Release
+name: Pre Release
 
 on:
   push:
-    # Publish `v1.2.3` tags as releases.
     tags:
-      - v*
+      - 'pre-*'
 
 jobs:
   build:
@@ -115,15 +114,6 @@ jobs:
       # ==============================
       #       Create release
       # ==============================
-      - name: Generate Change Log
-        id: changelog
-        run: |
-          chmod 755 ./.github/generate_change_log.sh
-          CHANGELOG=$(./.github/generate_change_log.sh ${{ env.RELEASE_VERSION}})
-
-          echo "CHANGELOG<<EOF" >> $GITHUB_ENV
-          echo "$CHANGELOG" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
 
       - name: Create Release
         id: create_release
@@ -134,9 +124,10 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
           body: |
-            ${{ env.CHANGELOG }}
-          draft: false
-          prerelease: false
+            versing: ${{ env.RELEASE_VERSION}}
+            git commit: ${{ github.sha }}
+          draft: true
+          prerelease: true
 
       # Check downloaded files
       - run: ls


### PR DESCRIPTION
### Description

In order to make it easier to test before the new version is released, make a CI flow of the pre-release version to testing before the official release.

### Rationale

This ci process will draft a pre-release page, but will not publish it.
**Notice: please tag a new version with `pre-` prefix.**

### Example

![image](https://user-images.githubusercontent.com/25412254/143534226-d84d9918-0047-4af1-8f79-ef3434095f48.png)

### Changes

Notable changes: 
* .github/workflows/pre-release.yml
* .github/workflows/release.yml
* .github/generate_change_log.sh

