### PR TITLE
prepare for release v.1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Changelog
+
+## v1.1.6
+BUGFIX
+* [\#582](https://github.com/binance-chain/bsc/pull/582) the DoS vulnerabilities fixed in go-ethereum v1.10.9
+
+IMPROVEMENT
+* [\#578](https://github.com/binance-chain/bsc/pull/578) reduce memory allocation and upgrade snappy version
+
+FEATURES
+* [\#570](https://github.com/binance-chain/bsc/pull/570) reannounce local pending transactions
+
 ## v1.1.5
 BUGFIX
 * [\#509](https://github.com/binance-chain/bsc/pull/509) fix graceful shutdown bug

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 1  // Minor version component of the current release
-	VersionPatch = 5  // Patch version component of the current release
+	VersionPatch = 6  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
This is a hotfix version. including a DoS issue fix from go-ethereum, leveldb improvement from go-ethereum, and a feature to improve p2p tx broadcast function.

### Changes
BUGFIX
* [\#582](https://github.com/binance-chain/bsc/pull/582) the DoS vulnerabilities fixed in go-ethereum v1.10.9

IMPROVEMENT
* [\#578](https://github.com/binance-chain/bsc/pull/578) reduce memory allocation and upgrade snappy version

FEATURES
* [\#570](https://github.com/binance-chain/bsc/pull/570) reannounce local pending transactions
