### PR TITLE
[R4R]fix state inconsistent when doing diffsync

### DIFF
--- a/.github/release.env
+++ b/.github/release.env
@@ -1,2 +1,2 @@
-MAINNET_FILE_URL="https://github.com/binance-chain/bsc/releases/download/v1.1.2/mainnet.zip"
-TESTNET_FILE_URL="https://github.com/binance-chain/bsc/releases/download/v1.1.2/testnet.zip"
+MAINNET_FILE_URL="https://github.com/binance-chain/bsc/releases/download/v1.1.6/mainnet.zip"
+TESTNET_FILE_URL="https://github.com/binance-chain/bsc/releases/download/v1.1.6/testnet.zip"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.1.7
+
+BUGFIX
+* [\#628](https://github.com/binance-chain/bsc/pull/628) fix state inconsistent when doing diffsync
+
 ## v1.1.6
 BUGFIX
 * [\#582](https://github.com/binance-chain/bsc/pull/582) the DoS vulnerabilities fixed in go-ethereum v1.10.9

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -253,7 +253,7 @@ func (p *LightStateProcessor) LightProcess(diffLayer *types.DiffLayer, block *ty
 
 				//update storage
 				latestRoot := common.BytesToHash(latestAccount.Root)
-				if latestRoot != previousAccount.Root && latestRoot != types.EmptyRootHash {
+				if latestRoot != previousAccount.Root {
 					accountTrie, err := statedb.Database().OpenStorageTrie(addrHash, previousAccount.Root)
 					if err != nil {
 						errChan <- err

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 1  // Minor version component of the current release
-	VersionPatch = 6  // Patch version component of the current release
+	VersionPatch = 7  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description
This PR is to fix a possible inconsistent state when doing diffsync. Since it is a syncing vulnerability which impact many clients, will release v1.1.7 especially for this patch.

### Rationale
Diffsync will assemble the modification to MPT and snapshot according to the received difflayer and verify against the block header.  In some cases(will disclose in future), the modification to MPT and snapshot is incorrect.

The  problematic logic is apply too stick condition to modify the smart contract trie: https://github.com/binance-chain/bsc/blob/0b575443c43f47f2f50ed5549d2bcaf7ccc39ab4/core/state_processor.go#L256

### Example
The current release, if you come across with *bad block* error with log message like: `expected tx hash xx, get xx, nonce xx, to xx, value xx, gas xx, gasPrice xx, data xx`. Here are some steps you can try to recover your node:

1. stop The node.
2. upgrade the binary to the release with this patch.
3. start your node with `--snapshot=false`
4. Wait for few minutes(it denpens on how fast your nodes are), until the block height is 128 higher than where it stopped.
5. restart the node with `--snapshot=true`
6. The node will continue to sync and repair the corrupt data.

### Changes
All the client that use `diffsync`  is suggested to upgrade

### Checks
It is been verified on Unittest and Testnet.

### Related issues
No
