### PR TITLE
[R4R] add timeout for stopping p2p server

### DIFF
--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -239,6 +239,76 @@ func testForkIDSplit(t *testing.T, protocol uint) {
 func TestRecvTransactions65(t *testing.T) { testRecvTransactions(t, eth.ETH65) }
 func TestRecvTransactions66(t *testing.T) { testRecvTransactions(t, eth.ETH66) }
 
+func TestWaitDiffExtensionTimout(t *testing.T) {
+	t.Parallel()
+
+	// Create a message handler, configure it to accept transactions and watch them
+	handler := newTestHandler()
+	defer handler.close()
+
+	// Create a source peer to send messages through and a sink handler to receive them
+	_, p2pSink := p2p.MsgPipe()
+	defer p2pSink.Close()
+
+	protos := []p2p.Protocol{
+		{
+			Name:    "diff",
+			Version: 1,
+		},
+	}
+
+	sink := eth.NewPeer(eth.ETH67, p2p.NewPeerWithProtocols(enode.ID{2}, protos, "", []p2p.Cap{
+		{
+			"diff",
+			1,
+		},
+	}), p2pSink, nil)
+	defer sink.Close()
+
+	err := handler.handler.runEthPeer(sink, func(peer *eth.Peer) error {
+		return eth.Handle((*ethHandler)(handler.handler), peer)
+	})
+
+	if err == nil || err.Error() != "peer wait timeout" {
+		t.Fatalf("error should be `peer wait timeout`")
+	}
+}
+
+func TestWaitSnapExtensionTimout(t *testing.T) {
+	t.Parallel()
+
+	// Create a message handler, configure it to accept transactions and watch them
+	handler := newTestHandler()
+	defer handler.close()
+
+	// Create a source peer to send messages through and a sink handler to receive them
+	_, p2pSink := p2p.MsgPipe()
+	defer p2pSink.Close()
+
+	protos := []p2p.Protocol{
+		{
+			Name:    "snap",
+			Version: 1,
+		},
+	}
+
+	sink := eth.NewPeer(eth.ETH67, p2p.NewPeerWithProtocols(enode.ID{2}, protos, "", []p2p.Cap{
+		{
+			"snap",
+			1,
+		},
+	}), p2pSink, nil)
+	defer sink.Close()
+
+	err := handler.handler.runEthPeer(sink, func(peer *eth.Peer) error {
+		return eth.Handle((*ethHandler)(handler.handler), peer)
+	})
+
+	if err == nil || err.Error() != "peer wait timeout" {
+		t.Fatalf("error should be `peer wait timeout`")
+	}
+}
+
 func testRecvTransactions(t *testing.T, protocol uint) {
 	t.Parallel()
 

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -259,8 +259,8 @@ func TestWaitDiffExtensionTimout(t *testing.T) {
 
 	sink := eth.NewPeer(eth.ETH67, p2p.NewPeerWithProtocols(enode.ID{2}, protos, "", []p2p.Cap{
 		{
-			"diff",
-			1,
+			Name:    "diff",
+			Version: 1,
 		},
 	}), p2pSink, nil)
 	defer sink.Close()
@@ -294,8 +294,8 @@ func TestWaitSnapExtensionTimout(t *testing.T) {
 
 	sink := eth.NewPeer(eth.ETH67, p2p.NewPeerWithProtocols(enode.ID{2}, protos, "", []p2p.Cap{
 		{
-			"snap",
-			1,
+			Name:    "snap",
+			Version: 1,
 		},
 	}), p2pSink, nil)
 	defer sink.Close()

--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -58,7 +58,7 @@ var (
 const (
 	// extensionWaitTimeout is the maximum allowed time for the extension wait to
 	// complete before dropping the connection as malicious.
-	extensionWaitTimeout = 5 * time.Second
+	extensionWaitTimeout = 10 * time.Second
 )
 
 // peerSet represents the collection of active peers currently participating in

--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"math/big"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/eth/downloader"
@@ -38,17 +39,26 @@ var (
 	// to the peer set, but one with the same id already exists.
 	errPeerAlreadyRegistered = errors.New("peer already registered")
 
+	// errPeerWaitTimeout is returned if a peer waits extension for too long
+	errPeerWaitTimeout = errors.New("peer wait timeout")
+
 	// errPeerNotRegistered is returned if a peer is attempted to be removed from
 	// a peer set, but no peer with the given id exists.
 	errPeerNotRegistered = errors.New("peer not registered")
 
 	// errSnapWithoutEth is returned if a peer attempts to connect only on the
-	// snap protocol without advertizing the eth main protocol.
+	// snap protocol without advertising the eth main protocol.
 	errSnapWithoutEth = errors.New("peer connected on snap without compatible eth support")
 
 	// errDiffWithoutEth is returned if a peer attempts to connect only on the
-	// diff protocol without advertizing the eth main protocol.
+	// diff protocol without advertising the eth main protocol.
 	errDiffWithoutEth = errors.New("peer connected on diff without compatible eth support")
+)
+
+const (
+	// extensionWaitTimeout is the maximum allowed time for the extension wait to
+	// complete before dropping the connection as malicious.
+	extensionWaitTimeout = 5 * time.Second
 )
 
 // peerSet represents the collection of active peers currently participating in
@@ -169,7 +179,16 @@ func (ps *peerSet) waitSnapExtension(peer *eth.Peer) (*snap.Peer, error) {
 	ps.snapWait[id] = wait
 	ps.lock.Unlock()
 
-	return <-wait, nil
+	select {
+	case peer := <-wait:
+		return peer, nil
+
+	case <-time.After(extensionWaitTimeout):
+		ps.lock.Lock()
+		delete(ps.snapWait, id)
+		ps.lock.Unlock()
+		return nil, errPeerWaitTimeout
+	}
 }
 
 // waitDiffExtension blocks until all satellite protocols are connected and tracked
@@ -203,7 +222,16 @@ func (ps *peerSet) waitDiffExtension(peer *eth.Peer) (*diff.Peer, error) {
 	ps.diffWait[id] = wait
 	ps.lock.Unlock()
 
-	return <-wait, nil
+	select {
+	case peer := <-wait:
+		return peer, nil
+
+	case <-time.After(extensionWaitTimeout):
+		ps.lock.Lock()
+		delete(ps.diffWait, id)
+		ps.lock.Unlock()
+		return nil, errPeerWaitTimeout
+	}
 }
 
 func (ps *peerSet) GetDiffPeer(pid string) downloader.IDiffPeer {

--- a/eth/protocols/diff/handshake.go
+++ b/eth/protocols/diff/handshake.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// handshakeTimeout is the maximum allowed time for the `diff` handshake to
-	// complete before dropping the connection.= as malicious.
+	// complete before dropping the connection as malicious.
 	handshakeTimeout = 5 * time.Second
 )
 

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -129,6 +129,16 @@ func NewPeer(id enode.ID, name string, caps []Cap) *Peer {
 	return peer
 }
 
+// NewPeerWithProtocols returns a peer for testing purposes.
+func NewPeerWithProtocols(id enode.ID, protocols []Protocol, name string, caps []Cap) *Peer {
+	pipe, _ := net.Pipe()
+	node := enode.SignNull(new(enr.Record), id)
+	conn := &conn{fd: pipe, transport: nil, node: node, caps: caps, name: name}
+	peer := newPeer(log.Root(), conn, protocols)
+	close(peer.closed) // ensures Disconnect doesn't block
+	return peer
+}
+
 // ID returns the node's public key.
 func (p *Peer) ID() enode.ID {
 	return p.rw.node.ID()

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -63,6 +63,9 @@ const (
 
 	// Maximum amount of time allowed for writing a complete message.
 	frameWriteTimeout = 20 * time.Second
+
+	// Maximum time to wait before stop the p2p server
+	stopTimeout = 5 * time.Second
 )
 
 var errServerStopped = errors.New("server stopped")
@@ -403,7 +406,18 @@ func (srv *Server) Stop() {
 	}
 	close(srv.quit)
 	srv.lock.Unlock()
-	srv.loopWG.Wait()
+
+	stopChan := make(chan struct{})
+	go func() {
+		srv.loopWG.Wait()
+		close(stopChan)
+	}()
+
+	select {
+	case <-stopChan:
+	case <-time.After(stopTimeout):
+		log.Warn("stop p2p server timeout, forcing stop")
+	}
 }
 
 // sharedUDPConn implements a shared connection. Write sends messages to the underlying connection while read returns

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -416,7 +416,7 @@ func (srv *Server) Stop() {
 	select {
 	case <-stopChan:
 	case <-time.After(stopTimeout):
-		log.Warn("stop p2p server timeout, forcing stop")
+		srv.log.Warn("stop p2p server timeout, forcing stop")
 	}
 }
 

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -203,6 +203,29 @@ func TestServerDial(t *testing.T) {
 	}
 }
 
+func TestServerStopTimeout(t *testing.T) {
+	srv := &Server{Config: Config{
+		PrivateKey:  newkey(),
+		MaxPeers:    1,
+		NoDiscovery: true,
+		Logger:      testlog.Logger(t, log.LvlTrace).New("server", "1"),
+	}}
+	srv.Start()
+	srv.loopWG.Add(1)
+
+	stopChan := make(chan struct{})
+	go func() {
+		srv.Stop()
+		close(stopChan)
+	}()
+
+	select {
+	case <-stopChan:
+	case <-time.After(10 * time.Second):
+		t.Error("server should be shutdown in 10 seconds")
+	}
+}
+
 // This test checks that RemovePeer disconnects the peer if it is connected.
 func TestServerRemovePeerDisconnect(t *testing.T) {
 	srv1 := &Server{Config: Config{


### PR DESCRIPTION
### Description

For now, when accepting p2p peers in p2p server, we will run `runEthPeer` and `RunPeer` in `diffHandler` and `snapHandler` concurrently, so sometimes `runEthPeer` will hang there for waiting for the signal that it missed before it runninng. 

This will cause we can not stop the bsc node gracefully, so we add a timeout for stopping p2p server and a timeout for handling p2p peers.

### Rationale

When we can not stop the bsc node gracefully, we will see this in the profile:

``` go
goroutine 78355508 [chan receive, 100 minutes]:
github.com/ethereum/go-ethereum/eth.(*peerSet).waitDiffExtension(0xc000eb69b0, 0xc06931f5e0)
	github.com/ethereum/go-ethereum/eth/peerset.go:206 +0x17e
github.com/ethereum/go-ethereum/eth.(*handler).runEthPeer(0xc0031fe000, 0xc06931f5e0, 0xc193063f68)
	github.com/ethereum/go-ethereum/eth/handler.go:261 +0x19c
github.com/ethereum/go-ethereum/eth.(*ethHandler).RunPeer(0x43, 0xc2c490a600, 0x18c6a78)
	github.com/ethereum/go-ethereum/eth/handler_eth.go:46 +0x19
github.com/ethereum/go-ethereum/eth/protocols/eth.MakeProtocols.func1(0x47bcd9, {0x18c6a78, 0xc23a41eb40})
	github.com/ethereum/go-ethereum/eth/protocols/eth/handler.go:117 +0x122
github.com/ethereum/go-ethereum/p2p.(*Peer).startProtocols.func1()
	github.com/ethereum/go-ethereum/p2p/peer.go:396 +0x8c
created by github.com/ethereum/go-ethereum/p2p.(*Peer).startProtocols
	github.com/ethereum/go-ethereum/p2p/peer.go:394 +0xb3
```

### Changes

Notable changes: 
* add a timeout for handling p2p peers
* add a timeout for stop p2p server



