### PR TITLE
[R4R] add ARM binaries for release pipeline

### DIFF
--- a/.github/generate_change_log.sh
+++ b/.github/generate_change_log.sh
@@ -24,6 +24,10 @@ TESTNET_ZIP_SUM="$(checksum ./testnet.zip)"
 LINUX_BIN_SUM="$(checksum ./linux/geth)"
 MAC_BIN_SUM="$(checksum ./macos/geth)"
 WINDOWS_BIN_SUM="$(checksum ./windows/geth.exe)"
+ARM5_BIN_SUM="$(checksum ./arm5/geth-linux-arm-5)"
+ARM6_BIN_SUM="$(checksum ./arm6/geth-linux-arm-6)"
+ARM7_BIN_SUM="$(checksum ./arm7/geth-linux-arm-7)"
+ARM64_BIN_SUM="$(checksum ./arm64/geth-linux-arm64)"
 OUTPUT=$(cat <<-END
 ## Changelog\n
 ${CHANGE_LOG}\n
@@ -35,6 +39,10 @@ ${CHANGE_LOG}\n
 | geth_linux | ${LINUX_BIN_SUM} |\n
 | geth_mac  | ${MAC_BIN_SUM} |\n
 | geth_windows  | ${WINDOWS_BIN_SUM} |\n
+| geth_linux_arm5  | ${ARM5_BIN_SUM} |\n
+| geth_linux_arm6  | ${ARM6_BIN_SUM} |\n
+| geth_linux_arm7  | ${ARM7_BIN_SUM} |\n
+| geth_linux_arm64  | ${ARM64_BIN_SUM} |\n
 END
 )
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -46,6 +46,19 @@ jobs:
         run: make geth
 
       # ==============================
+      #       Cross Compile for ARM
+      # ==============================
+
+      - name: Build Binary for ARM
+        if: matrix.os == 'ubuntu-18.04'
+        env:
+          GOPATH: /home/runner/work/woodpecker/go
+        run: |
+          mkdir -p $GOPATH/src/github.com/binance-chain/bsc/
+          cp -r ./* $GOPATH/src/github.com/binance-chain/bsc/
+          cd $GOPATH/src/github.com/binance-chain/bsc/ && make geth-linux-arm
+
+      # ==============================
       #       Upload artifacts
       # ==============================
 
@@ -69,6 +82,34 @@ jobs:
         with:
           name: windows
           path: ./build/bin/geth.exe
+
+      - name: Upload ARM-5 Build
+        uses: actions/upload-artifact@v2
+        if: matrix.os == 'ubuntu-18.04'
+        with:
+          name: arm5
+          path: /home/runner/work/woodpecker/go/src/github.com/binance-chain/bsc/build/bin/geth-linux-arm-5
+      
+      - name: Upload ARM-6 Build
+        uses: actions/upload-artifact@v2
+        if: matrix.os == 'ubuntu-18.04'
+        with:
+          name: arm6
+          path: /home/runner/work/woodpecker/go/src/github.com/binance-chain/bsc/build/bin/geth-linux-arm-6
+
+      - name: Upload ARM-7 Build
+        uses: actions/upload-artifact@v2
+        if: matrix.os == 'ubuntu-18.04'
+        with:
+          name: arm7
+          path: /home/runner/work/woodpecker/go/src/github.com/binance-chain/bsc/build/bin/geth-linux-arm-7
+
+      - name: Upload ARM-64 Build
+        uses: actions/upload-artifact@v2
+        if: matrix.os == 'ubuntu-18.04'
+        with:
+          name: arm64
+          path: /home/runner/work/woodpecker/go/src/github.com/binance-chain/bsc/build/bin/geth-linux-arm64
 
   release:
     name: Release
@@ -102,6 +143,30 @@ jobs:
         with:
           name: windows
           path: ./windows
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: arm5
+          path: ./arm5
+      
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: arm6
+          path: ./arm6
+      
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: arm7
+          path: ./arm7
+      
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: arm64
+          path: ./arm64
       
       - name: Download Config File
         run: |
@@ -160,6 +225,46 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           asset_path: ./windows/geth.exe
           asset_name: geth_windows.exe
+          asset_content_type: application/octet-stream
+
+      - name: Upload Release Asset - Linux ARM 5
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./arm5/geth-linux-arm-5
+          asset_name: geth-linux-arm-5
+          asset_content_type: application/octet-stream
+      
+      - name: Upload Release Asset - Linux ARM 6
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./arm6/geth-linux-arm-6
+          asset_name: geth-linux-arm-6
+          asset_content_type: application/octet-stream
+
+      - name: Upload Release Asset - Linux ARM 7
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./arm7/geth-linux-arm-7
+          asset_name: geth-linux-arm-7
+          asset_content_type: application/octet-stream
+
+      - name: Upload Release Asset - Linux ARM 64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./arm64/geth-linux-arm64
+          asset_name: geth-linux-arm64
           asset_content_type: application/octet-stream
       
       - name: Upload Release Asset - MAINNET.ZIP

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,19 @@ jobs:
         run: make geth
 
       # ==============================
+      #       Cross Compile for ARM
+      # ==============================
+
+      - name: Build Binary for ARM
+        if: matrix.os == 'ubuntu-18.04'
+        env:
+          GOPATH: /home/runner/work/woodpecker/go
+        run: |
+          mkdir -p $GOPATH/src/github.com/binance-chain/bsc/
+          cp -r ./* $GOPATH/src/github.com/binance-chain/bsc/
+          cd $GOPATH/src/github.com/binance-chain/bsc/ && make geth-linux-arm
+
+      # ==============================
       #       Upload artifacts
       # ==============================
 
@@ -70,6 +83,34 @@ jobs:
         with:
           name: windows
           path: ./build/bin/geth.exe
+
+      - name: Upload ARM-5 Build
+        uses: actions/upload-artifact@v2
+        if: matrix.os == 'ubuntu-18.04'
+        with:
+          name: arm5
+          path: /home/runner/work/woodpecker/go/src/github.com/binance-chain/bsc/build/bin/geth-linux-arm-5
+      
+      - name: Upload ARM-6 Build
+        uses: actions/upload-artifact@v2
+        if: matrix.os == 'ubuntu-18.04'
+        with:
+          name: arm6
+          path: /home/runner/work/woodpecker/go/src/github.com/binance-chain/bsc/build/bin/geth-linux-arm-6
+
+      - name: Upload ARM-7 Build
+        uses: actions/upload-artifact@v2
+        if: matrix.os == 'ubuntu-18.04'
+        with:
+          name: arm7
+          path: /home/runner/work/woodpecker/go/src/github.com/binance-chain/bsc/build/bin/geth-linux-arm-7
+
+      - name: Upload ARM-64 Build
+        uses: actions/upload-artifact@v2
+        if: matrix.os == 'ubuntu-18.04'
+        with:
+          name: arm64
+          path: /home/runner/work/woodpecker/go/src/github.com/binance-chain/bsc/build/bin/geth-linux-arm64
 
   release:
     name: Release
@@ -103,6 +144,30 @@ jobs:
         with:
           name: windows
           path: ./windows
+      
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: arm5
+          path: ./arm5
+      
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: arm6
+          path: ./arm6
+      
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: arm7
+          path: ./arm7
+      
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: arm64
+          path: ./arm64
       
       - name: Download Config File
         run: |
@@ -169,6 +234,46 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           asset_path: ./windows/geth.exe
           asset_name: geth_windows.exe
+          asset_content_type: application/octet-stream
+      
+      - name: Upload Release Asset - Linux ARM 5
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./arm5/geth-linux-arm-5
+          asset_name: geth-linux-arm-5
+          asset_content_type: application/octet-stream
+      
+      - name: Upload Release Asset - Linux ARM 6
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./arm6/geth-linux-arm-6
+          asset_name: geth-linux-arm-6
+          asset_content_type: application/octet-stream
+
+      - name: Upload Release Asset - Linux ARM 7
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./arm7/geth-linux-arm-7
+          asset_name: geth-linux-arm-7
+          asset_content_type: application/octet-stream
+
+      - name: Upload Release Asset - Linux ARM 64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./arm64/geth-linux-arm64
+          asset_name: geth-linux-arm64
           asset_content_type: application/octet-stream
       
       - name: Upload Release Asset - MAINNET.ZIP


### PR DESCRIPTION
### Description

The release page adds the binary file of the ARM system.

### Rationale

Github Action doesn't provide the origin ARM OS runner. 
So the binaries of ARM will be built by `xgo` tools.

#### Run locally
```
make geth-linux-arm
```
*NOTE*: `xgo` lib does not support go modules, please make sure your code files are under the path `$GOPATH/src`

### Example

![image](https://user-images.githubusercontent.com/25412254/149456868-98c30188-cf99-4861-a7d8-fdb93d1eee7c.png)

### Changes

Notable changes: 
* add arm binaries for release pipeline

### Related issues

[#712](https://github.com/binance-chain/bsc/issues/712)
