### PR TITLE
[R4R]prepare for relase v1.1.8

### DIFF
--- a/.github/release.env
+++ b/.github/release.env
@@ -1,2 +1,2 @@
-MAINNET_FILE_URL="https://github.com/binance-chain/bsc/releases/download/v1.1.6/mainnet.zip"
-TESTNET_FILE_URL="https://github.com/binance-chain/bsc/releases/download/v1.1.6/testnet.zip"
+MAINNET_FILE_URL="https://github.com/binance-chain/bsc/releases/download/v1.1.7/mainnet.zip"
+TESTNET_FILE_URL="https://github.com/binance-chain/bsc/releases/download/v1.1.7/testnet.zip"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v1.1.8
+FEATURES
+* [\#668](https://github.com/binance-chain/bsc/pull/668) implement State Verification && Snapshot Commit pipeline
+* [\#581](https://github.com/binance-chain/bsc/pull/581) implement geth native trace 
+* [\#543](https://github.com/binance-chain/bsc/pull/543) implement offline block prune tools
+
+IMPROVEMENT
+* [\#704](https://github.com/binance-chain/bsc/pull/704) prefetch state by applying the transactions within one block 
+* [\#713](https://github.com/binance-chain/bsc/pull/713) add ARM binaries for release pipeline
+
+BUGFIX
+* [\#667](https://github.com/binance-chain/bsc/pull/667) trie: reject deletions when verifying range proofs #667
+* [\#643](https://github.com/binance-chain/bsc/pull/643) add timeout for stopping p2p server to fix can not gracefully shutdown issue
+* [\#740](https://github.com/binance-chain/bsc/pull/740) update discord link which won't expire 
+
 ## v1.1.7
 
 BUGFIX

--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -15,17 +15,3 @@ add an example CLI or API response...
 Notable changes: 
 * add each change in a bullet point here
 * ...
-
-### Preflight checks
-
-- [ ] build passed (`make build`)
-- [ ] tests passed (`make test`)
-- [ ] manual transaction test passed
-
-### Already reviewed by
-
-...
-
-### Related issues
-
-... reference related issue #'s here ...

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 1  // Minor version component of the current release
-	VersionPatch = 7  // Patch version component of the current release
+	VersionPatch = 8  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description

Prepare for the release v1.1.8
### Rationale
FEATURES
* [\#668](https://github.com/binance-chain/bsc/pull/668) implement State Verification && Snapshot Commit pipeline
* [\#581](https://github.com/binance-chain/bsc/pull/581) implement geth native trace 
* [\#543](https://github.com/binance-chain/bsc/pull/543) implement offline block prune tools

IMPROVEMENT
* [\#704](https://github.com/binance-chain/bsc/pull/704) prefetch state by applying the transactions within one block 
* [\#713](https://github.com/binance-chain/bsc/pull/713) add ARM binaries for release pipeline

BUGFIX
* [\#667](https://github.com/binance-chain/bsc/pull/667) trie: reject deletions when verifying range proofs #667
* [\#643](https://github.com/binance-chain/bsc/pull/643) add timeout for stopping p2p server to fix can not gracefully shutdown issue
* [\#740](https://github.com/binance-chain/bsc/pull/740) update discord link which won't expire 


### Example

add an example CLI or API response...

### Changes

