### PR TITLE
Update evm with interpreter when new

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -181,8 +181,9 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 
 	// vmConfig.EVMInterpreter will be used by EVM-C, it won't be checked here
 	// as we always want to have the built-in EVM as the failover option.
-	evm.interpreters = append(evm.interpreters, NewEVMInterpreter(evm, vmConfig))
-	evm.interpreter = evm.interpreters[0]
+	interpreter := NewEVMInterpreter(evm, vmConfig)
+	evm.interpreters = append(evm.interpreters, interpreter)
+	evm.interpreter = interpreter
 
 	return evm
 }


### PR DESCRIPTION
### Description

  Recently, BSC geth full node syncing block is getting slow, much slower than highestBlock. It is not able to catch up at all.

### Rationale

  I believe the root cause is coming from commit 2ce00adb5 updating NewEVM() with sync.Pool, which is a good way to reduce GC
https://github.com/binance-chain/bsc/blob/859186f299fa94fada3e92608db1392be1a45599/core/vm/evm.go#L154
  However, there is might wrong when updating interpreter
https://github.com/binance-chain/bsc/blob/859186f299fa94fada3e92608db1392be1a45599/core/vm/evm.go#L185
  I think should assign an interpreter with the new one instead of the first one from the interpreters. Additional there is a logic make it call interpreter recursively, and that call is an io call unfortunately
https://github.com/binance-chain/bsc/blob/859186f299fa94fada3e92608db1392be1a45599/core/vm/evm.go#L78
  Please tell me if there is another situation I need to consider about, thanks

![Screen Shot 2022-01-29 at 12 26 11 PM](https://user-images.githubusercontent.com/3282795/151654836-765459c8-e591-4b66-92b2-3933386e8336.png)

### Example

### Changes

Notable changes: 
* Both assign the new interpreter to evm.interpreter and append it to evm.interpreters
